### PR TITLE
add anon subscribe now banner

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -36,7 +36,7 @@
     "o-typography": "^5.4.2",
     "o-share": "^6.0.0",
     "o-grid": "^4.3.6",
-    "n-alert-banner": "^0.7.0",
+    "n-alert-banner": "^0.8.0",
     "o-icons": "^5.0.0"
   },
   "devDependencies": {

--- a/demos/templates/index.html
+++ b/demos/templates/index.html
@@ -1,3 +1,5 @@
+<div class="o-header-before"></div>
+
 <div id='site-navigation'>
 	{{> o-header }}
 </div>

--- a/main.scss
+++ b/main.scss
@@ -11,3 +11,4 @@
 
 @import './src/components/invite-colleagues/main';
 @import './src/components/desktop-app-banner/main';
+@import './src/components/anon-subscribe-now-teal/main';

--- a/manifest.js
+++ b/manifest.js
@@ -14,5 +14,9 @@ module.exports = {
 	paymentFailure: {
 		partial: 'top/payment-failure',
 		messageId: 'paymentFailure'
+	},
+	anonSubscribeNow: {
+		partial: 'top/anon-subscribe-now-teal',
+		messageId: 'anonSubscribeNow',
 	}
 };

--- a/secret-squirrel.js
+++ b/secret-squirrel.js
@@ -6,7 +6,8 @@ module.exports = {
 	strings: {
 		deny: [],
 		denyOverrides: [
-			'45e2193a-f479-11e7-8c80-69ca88a9e8d1' // README.md:155
+			'45e2193a-f479-11e7-8c80-69ca88a9e8d1', // README.md:162
+			'27e66825-bc4f-ba59-a3cd-1a8f08579bfe' // templates/partials/top/anon-subscribe-now-teal.html:3|11
 		]
 	}
 };

--- a/src/components/anon-subscribe-now-teal/main.js
+++ b/src/components/anon-subscribe-now-teal/main.js
@@ -1,0 +1,16 @@
+module.exports = function customSetup (banner, done) {
+  const actions = banner.innerElement.querySelector('div.n-alert-banner__actions');
+  const button = banner.innerElement.querySelector('a.n-alert-banner__button');
+
+  actions.className += ' n-alert-banner__actions--clickarea';
+  actions.addEventListener('click', event => {
+    // Hit test to see if the click originated on expanded click area
+    if (event.target !== button) {
+      event.stopPropagation();
+      button.click();
+      return false;
+    }
+  });
+
+  done();
+};

--- a/src/components/anon-subscribe-now-teal/main.js
+++ b/src/components/anon-subscribe-now-teal/main.js
@@ -1,13 +1,13 @@
 module.exports = function customSetup (banner, done) {
-	const actions = banner.innerElement.querySelector('div.n-alert-banner__actions');
-	const button = banner.innerElement.querySelector('a.n-alert-banner__button');
+	const bannerActions = banner.innerElement.querySelector('div.n-alert-banner__actions');
+	const bannerButton = banner.innerElement.querySelector('a.n-alert-banner__button');
 
-	actions.className += ' n-alert-banner__actions--clickarea';
-	actions.addEventListener('click', event => {
+	bannerActions.className += ' n-alert-banner__actions--clickarea';
+	bannerActions.addEventListener('click', clickEvent => {
 		// Hit test to see if the click originated on expanded click area
-		if (event.target !== button) {
-			event.stopPropagation();
-			button.click();
+		if (clickEvent.target !== bannerButton) {
+			clickEvent.stopPropagation();
+			bannerButton.click();
 			return false;
 		}
 	});

--- a/src/components/anon-subscribe-now-teal/main.js
+++ b/src/components/anon-subscribe-now-teal/main.js
@@ -1,16 +1,16 @@
 module.exports = function customSetup (banner, done) {
-  const actions = banner.innerElement.querySelector('div.n-alert-banner__actions');
-  const button = banner.innerElement.querySelector('a.n-alert-banner__button');
+	const actions = banner.innerElement.querySelector('div.n-alert-banner__actions');
+	const button = banner.innerElement.querySelector('a.n-alert-banner__button');
 
-  actions.className += ' n-alert-banner__actions--clickarea';
-  actions.addEventListener('click', event => {
-    // Hit test to see if the click originated on expanded click area
-    if (event.target !== button) {
-      event.stopPropagation();
-      button.click();
-      return false;
-    }
-  });
+	actions.className += ' n-alert-banner__actions--clickarea';
+	actions.addEventListener('click', event => {
+		// Hit test to see if the click originated on expanded click area
+		if (event.target !== button) {
+			event.stopPropagation();
+			button.click();
+			return false;
+		}
+	});
 
-  done();
+	done();
 };

--- a/src/components/anon-subscribe-now-teal/main.scss
+++ b/src/components/anon-subscribe-now-teal/main.scss
@@ -1,16 +1,20 @@
 .n-alert-banner--marketing-anon-subscribe {
 
   .n-alert-banner__actions {
-      height: 46px;
-      max-width: 740px;
-      padding-right: 310px;
-      margin: 0 auto 0 auto;
-      background: url('https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fwww.ft.com%2F__assets%2Fcreatives%2Fproduct%2FPrintPackshot-2017-09-07_smallest.png?source=next') right bottom no-repeat;
-      background-size: auto 48px;
+    height: 46px;
+    max-width: 740px;
+    padding-right: 310px;
+    margin: 0 auto 0 auto;
+    background: url('https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fwww.ft.com%2F__assets%2Fcreatives%2Fproduct%2FPrintPackshot-2017-09-07_smallest.png?source=next') right bottom no-repeat;
+    background-size: auto 48px;
   }
 
   .n-alert-banner__action {
     padding-right: 0px;
+  }
+
+  .n-alert-banner__actions--clickarea {
+    cursor: pointer;
   }
 
 }

--- a/src/components/anon-subscribe-now-teal/main.scss
+++ b/src/components/anon-subscribe-now-teal/main.scss
@@ -1,5 +1,4 @@
 .n-alert-banner--marketing-anon-subscribe {
-
   .n-alert-banner__actions {
     height: 46px;
     max-width: 740px;
@@ -8,13 +7,10 @@
     background: url('https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fwww.ft.com%2F__assets%2Fcreatives%2Fproduct%2FPrintPackshot-2017-09-07_smallest.png?source=next') right bottom no-repeat;
     background-size: auto 48px;
   }
-
   .n-alert-banner__action {
     padding-right: 0px;
   }
-
   .n-alert-banner__actions--clickarea {
     cursor: pointer;
   }
-
 }

--- a/src/components/anon-subscribe-now-teal/main.scss
+++ b/src/components/anon-subscribe-now-teal/main.scss
@@ -1,11 +1,19 @@
 .n-alert-banner--marketing-anon-subscribe {
+	.n-alert-banner__outer {
+		height: 56px;
+	}
+	.n-alert-banner__inner {
+		display: table;
+	}
 	.n-alert-banner__actions {
-		height: 46px;
+		height: 56px;
 		max-width: 740px;
 		padding-right: 310px;
 		margin: 0 auto;
 		background: url('https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fwww.ft.com%2F__assets%2Fcreatives%2Fproduct%2FPrintPackshot-2017-09-07_smallest.png?source=next') right bottom no-repeat;
 		background-size: auto 48px;
+		display: table-cell;
+		vertical-align: middle;
 	}
 	.n-alert-banner__action {
 		padding-right: 0;

--- a/src/components/anon-subscribe-now-teal/main.scss
+++ b/src/components/anon-subscribe-now-teal/main.scss
@@ -1,4 +1,8 @@
 .n-alert-banner--marketing-anon-subscribe {
+	display: none;
+	@include oGridRespondTo('M') {
+		display: block;
+	}
 	.n-alert-banner__outer {
 		height: 56px;
 	}

--- a/src/components/anon-subscribe-now-teal/main.scss
+++ b/src/components/anon-subscribe-now-teal/main.scss
@@ -18,6 +18,9 @@
 	.n-alert-banner__action {
 		padding-right: 0;
 	}
+	.n-alert-banner__button {
+		line-height: 14px;
+	}
 	.n-alert-banner__actions--clickarea {
 		cursor: pointer;
 	}

--- a/src/components/anon-subscribe-now-teal/main.scss
+++ b/src/components/anon-subscribe-now-teal/main.scss
@@ -1,16 +1,16 @@
 .n-alert-banner--marketing-anon-subscribe {
-  .n-alert-banner__actions {
-    height: 46px;
-    max-width: 740px;
-    padding-right: 310px;
-    margin: 0 auto 0 auto;
-    background: url('https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fwww.ft.com%2F__assets%2Fcreatives%2Fproduct%2FPrintPackshot-2017-09-07_smallest.png?source=next') right bottom no-repeat;
-    background-size: auto 48px;
-  }
-  .n-alert-banner__action {
-    padding-right: 0px;
-  }
-  .n-alert-banner__actions--clickarea {
-    cursor: pointer;
-  }
+	.n-alert-banner__actions {
+		height: 46px;
+		max-width: 740px;
+		padding-right: 310px;
+		margin: 0 auto;
+		background: url('https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fwww.ft.com%2F__assets%2Fcreatives%2Fproduct%2FPrintPackshot-2017-09-07_smallest.png?source=next') right bottom no-repeat;
+		background-size: auto 48px;
+	}
+	.n-alert-banner__action {
+		padding-right: 0;
+	}
+	.n-alert-banner__actions--clickarea {
+		cursor: pointer;
+	}
 }

--- a/src/components/anon-subscribe-now-teal/main.scss
+++ b/src/components/anon-subscribe-now-teal/main.scss
@@ -1,0 +1,16 @@
+.n-alert-banner--marketing-anon-subscribe {
+
+  .n-alert-banner__actions {
+      height: 46px;
+      max-width: 740px;
+      padding-right: 310px;
+      margin: 0 auto 0 auto;
+      background: url('https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fwww.ft.com%2F__assets%2Fcreatives%2Fproduct%2FPrintPackshot-2017-09-07_smallest.png?source=next') right bottom no-repeat;
+      background-size: auto 48px;
+  }
+
+  .n-alert-banner__action {
+    padding-right: 0px;
+  }
+
+}

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,7 +1,9 @@
 const inviteColleagues = require('./invite-colleagues/main');
 const appBanner = require('./desktop-app-banner/main');
+const anonSubscribe = require('./anon-subscribe-now-teal/main');
 
 module.exports = {
 	b2bUpsellBanner: inviteColleagues,
-	appPromotingBanner: appBanner
+	appPromotingBanner: appBanner,
+	anonSubscribeNow: anonSubscribe
 };

--- a/templates/components/n-alert-banner.html
+++ b/templates/components/n-alert-banner.html
@@ -1,4 +1,4 @@
-<div class="n-alert-banner n-alert-banner--closed n-alert-banner--{{theme}}" data-n-component="n-alert-banner" data-n-messaging-component=""{{#if appendToElement}} data-n-alert-banner-append-to-element="{{appendToElement}}"{{/if}} data-n-alert-banner-auto-open="false" data-n-alert-banner-close-button="{{#if closeButton}}{{closeButton}}{{else}}true{{/if}}">
+<div class="n-alert-banner n-alert-banner--closed n-alert-banner--{{theme}}{{#if customClass}} {{customClass}}{{/if}}" data-n-component="n-alert-banner" data-n-messaging-component=""{{#if appendToElement}} data-n-alert-banner-append-to-element="{{appendToElement}}"{{/if}} data-n-alert-banner-auto-open="false" data-n-alert-banner-close-button="{{#if closeButton}}{{closeButton}}{{else}}true{{/if}}">
 	<div class="n-alert-banner__outer">
 		<div class="o-grid-container n-alert-banner__inner" data-n-alert-banner-inner="">
 			{{#if contentLong}}

--- a/templates/components/n-alert-banner.html
+++ b/templates/components/n-alert-banner.html
@@ -1,4 +1,4 @@
-<div class="n-alert-banner n-alert-banner--closed n-alert-banner--{{theme}}{{#if customClass}} {{customClass}}{{/if}}" data-n-component="n-alert-banner" data-n-messaging-component=""{{#if appendToElement}} data-n-alert-banner-append-to-element="{{appendToElement}}"{{/if}} data-n-alert-banner-auto-open="false" data-n-alert-banner-close-button="{{#if closeButton}}{{closeButton}}{{else}}true{{/if}}">
+<div class="n-alert-banner n-alert-banner--closed n-alert-banner--{{theme}}{{#if customClass}} {{customClass}}{{/if}}" data-n-component="n-alert-banner" data-n-messaging-component=""{{#if appendToElement}} data-n-alert-banner-append-to-element="{{appendToElement}}"{{/if}} data-n-alert-banner-auto-open="false" data-n-alert-banner-close-button="{{#if closeButton}}{{closeButton}}{{else}}true{{/if}}" {{#if customDataTrackableBanner}}data-trackable="{{customDataTrackableBanner}}"{{/if}}>
 	<div class="n-alert-banner__outer">
 		<div class="o-grid-container n-alert-banner__inner" data-n-alert-banner-inner="">
 			{{#if contentLong}}
@@ -13,15 +13,15 @@
 					{{{contentShort}}}
 				</div>
 			{{/if}}
-			<div class="n-alert-banner__actions">
+			<div class="n-alert-banner__actions" {{#if customDataTrackableActions}}data-trackable="{{customDataTrackableActions}}"{{/if}}>
 				{{#if buttonUrl}}
 					<div class="n-alert-banner__action">
-						<a href="{{buttonUrl}}" class="n-alert-banner__button" data-n-messaging-banner-action="" data-trackable="onsite-message-button">{{buttonLabel}}</a>
+						<a href="{{buttonUrl}}" class="n-alert-banner__button" data-n-messaging-banner-action="" data-trackable="{{#if customDataTrackableButton}}{{customDataTrackableButton}}{{else}}onsite-message-button{{/if}}">{{buttonLabel}}</a>
 					</div>
 				{{/if}}
 				{{#if linkUrl}}
 					<div class="n-alert-banner__action--secondary">
-						<a href={{linkUrl}} class="n-alert-banner__link" data-n-messaging-alert-banner-action="" data-trackable="onsite-message-link">{{linkLabel}}</a>
+						<a href={{linkUrl}} class="n-alert-banner__link" data-n-messaging-alert-banner-action="" data-trackable="{{#if customDataTrackableLink}}{{customDataTrackableLink}}{{else}}onsite-message-link{{/if}}">{{linkLabel}}</a>
 					</div>
 				{{/if}}
 			</div>

--- a/templates/partials/top/anon-subscribe-now-teal.html
+++ b/templates/partials/top/anon-subscribe-now-teal.html
@@ -5,4 +5,7 @@
 	appendToElement='.o-header-before'
 	closeButton='false'
 	customClass='n-alert-banner--marketing-anon-subscribe'
+	customDataTrackableBanner='marketing-promo:header'
+	customDataTrackableActions='marketing-promo:box'
+	customDataTrackableButton='marketing-promo:link'
 }}

--- a/templates/partials/top/anon-subscribe-now-teal.html
+++ b/templates/partials/top/anon-subscribe-now-teal.html
@@ -1,0 +1,21 @@
+{{> n-messaging-client/templates/components/n-alert-banner
+	theme='marketing'
+	buttonUrl='https://sub.ft.com/spa2_14/?segmentId=27e66825-bc4f-ba59-a3cd-1a8f08579bfe&utm_uk=WWAFL&utm_eu=WWAFM&utm_us=JJIBAF&utm_as=FFIBAX'
+	buttonLabel='Subscribe to the FT'
+	appendToElement='.o-header-before'
+	closeButton='false'
+}}
+
+<!-- <div class="n-header__marketing-promo" data-trackable="marketing-promo:header">
+	<div class="n-header__marketing-promo__container o-header__container">
+		<a href="https://sub.ft.com/spa2_14/?segmentId=27e66825-bc4f-ba59-a3cd-1a8f08579bfe&utm_uk=WWAFL&utm_eu=WWAFM&utm_us=JJIBAF&utm_as=FFIBAX" class="n-header__marketing-promo__box" data-trackable="marketing-promo:box">
+			<div class="n-header__marketing-promo__link" data-trackable="marketing-promo:link">
+			{{#if @root.flags.priceFlashSale}}
+				<span>Limited time offer, subscribe &amp; save 25% </span>
+			{{else}}
+				<span aria-label="Subscribe to the Financial Times">Subscribe to the FT</span>
+			{{/if}}
+			</div>
+		</a>
+	</div>
+</div> -->

--- a/templates/partials/top/anon-subscribe-now-teal.html
+++ b/templates/partials/top/anon-subscribe-now-teal.html
@@ -4,18 +4,5 @@
 	buttonLabel='Subscribe to the FT'
 	appendToElement='.o-header-before'
 	closeButton='false'
+	customClass='n-alert-banner--marketing-anon-subscribe'
 }}
-
-<!-- <div class="n-header__marketing-promo" data-trackable="marketing-promo:header">
-	<div class="n-header__marketing-promo__container o-header__container">
-		<a href="https://sub.ft.com/spa2_14/?segmentId=27e66825-bc4f-ba59-a3cd-1a8f08579bfe&utm_uk=WWAFL&utm_eu=WWAFM&utm_us=JJIBAF&utm_as=FFIBAX" class="n-header__marketing-promo__box" data-trackable="marketing-promo:box">
-			<div class="n-header__marketing-promo__link" data-trackable="marketing-promo:link">
-			{{#if @root.flags.priceFlashSale}}
-				<span>Limited time offer, subscribe &amp; save 25% </span>
-			{{else}}
-				<span aria-label="Subscribe to the Financial Times">Subscribe to the FT</span>
-			{{/if}}
-			</div>
-		</a>
-	</div>
-</div> -->

--- a/test/smoke.js
+++ b/test/smoke.js
@@ -10,6 +10,10 @@ const messages = [
 	{
 		name: 'paymentFailure',
 		slot: 'messageSlotTop'
+	},
+	{
+		name: 'anonSubscribeNow',
+		slot: 'messageSlotTop'
 	}
 ];
 


### PR DESCRIPTION
Porting the anonymous subscribe now banner to the n-messaging-client. In the core experience only the button (a tag) is clickable, this is enhanced to widen the click area to the whole background image for JS users.

| original | n-messaging |
| --- | --- |
| <img width="726" alt="screen shot 2018-02-02 at 16 07 53" src="https://user-images.githubusercontent.com/1721150/35742828-a33b110e-0833-11e8-8938-f03b036d9d1c.png"> | <img width="935" alt="screen shot 2018-02-02 at 16 19 22" src="https://user-images.githubusercontent.com/1721150/35743235-e145ef0e-0834-11e8-84c2-ade27f255d11.png"> |

| Chrome | Firefox | IE | Edge | Safari |
| --- | --- | --- | --- | --- |
| Enhanced | Enhanced | Core* | Enhanced | Enhanced|

\* Seems to be an JS issue with the demo page which stops the banner from being enhanced, haven't dug into it but the navigation is also broken.