### PR TITLE
use n-ui-foundations

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "o-banner": "^1.4.0",
     "o-share": "^6.0.0",
-    "n-alert-banner": "^0.7.0",
+    "n-alert-banner": "^0.9.0",
     "n-ui-foundations": "^3.0.0"
   },
   "devDependencies": {

--- a/bower.json
+++ b/bower.json
@@ -31,16 +31,11 @@
   ],
   "dependencies": {
     "o-banner": "^1.4.0",
-    "o-buttons": "^5.8.2",
-    "o-colors": "^4.1.5",
-    "o-typography": "^5.4.2",
     "o-share": "^6.0.0",
-    "o-grid": "^4.3.6",
     "n-alert-banner": "^0.7.0",
-    "o-icons": "^5.0.0"
+    "n-ui-foundations": "^3.0.0"
   },
   "devDependencies": {
-    "n-ui-foundations": "^3.0.0",
     "o-tracking": "^1.3.3"
   }
 }

--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -2,6 +2,7 @@
 @import '../../main';
 
 .mock-content {
+
 	h1 {
 		padding-top: 20px;
 	}

--- a/main.scss
+++ b/main.scss
@@ -1,17 +1,33 @@
+@import "o-buttons/main";
 @import "o-colors/main";
+@import "o-grid/main";
 @import "o-icons/main";
 @import "o-typography/main";
-@import "o-buttons/main";
 
-@import 'o-banner/main';
 @import 'n-alert-banner/main';
+@import 'o-banner/main';
+
+@include oFontsInclude(MetricWeb);
+@include oFontsInclude(MetricWeb, $weight: semibold);
 
 @include oBanner($class: 'n-messaging-banner', $themes: 'all');
 @include nAlertBanner($class: 'n-alert-banner', $themes: 'all');
 
-//ensure banner displays above other elements on page (e.g. imgs on article page)
+// ensure banner displays above other elements on page (e.g. imgs on article page)
 .n-messaging-banner {
 	z-index: 100;
+}
+
+// ensure the inner content of the banner is aligned to page content
+.n-alert-banner__inner {
+	@include oGridContainer();
+}
+
+// set font
+.n-alert-banner,
+.n-messaging-banner {
+	font-family: sans-serif;
+	font-size: 0.8125em;
 }
 
 @import './src/components/invite-colleagues/main';

--- a/main.scss
+++ b/main.scss
@@ -13,17 +13,17 @@
 @include oBanner($class: 'n-messaging-banner', $themes: 'all');
 @include nAlertBanner($class: 'n-alert-banner', $themes: 'all');
 
-// ensure banner displays above other elements on page (e.g. imgs on article page)
+// ensure the bottom o-banner displays above other elements on page (e.g. imgs on article page)
 .n-messaging-banner {
 	z-index: 100;
 }
 
-// ensure the inner content of the banner is aligned to page content
+// ensure the top n-alert-banner inner content is aligned to page content
 .n-alert-banner__inner {
 	@include oGridContainer();
 }
 
-// set font
+// set base font
 .n-alert-banner,
 .n-messaging-banner {
 	font-family: sans-serif;

--- a/main.scss
+++ b/main.scss
@@ -1,4 +1,8 @@
-@import 'n-ui-foundations/main';
+@import "o-colors/main";
+@import "o-icons/main";
+@import "o-typography/main";
+@import "o-buttons/main";
+
 @import 'o-banner/main';
 @import 'n-alert-banner/main';
 

--- a/main.scss
+++ b/main.scss
@@ -1,3 +1,4 @@
+@import 'n-ui-foundations/main';
 @import 'o-banner/main';
 @import 'n-alert-banner/main';
 

--- a/src/client/bottom-slot.js
+++ b/src/client/bottom-slot.js
@@ -3,8 +3,8 @@ const { messageEvent, listen } = require('./utils');
 
 const BANNER_CLASS = 'n-messaging-banner';
 const BANNER_ACTION_SELECTOR = '[data-n-messaging-banner-action]';
-const BANNER_BUTTON_SELECTOR = '.n-messaging-banner__button';
-const BANNER_LINK_SELECTOR = '.n-messaging-banner__link';
+const BANNER_BUTTON_SELECTOR = `.${BANNER_CLASS}__button`;
+const BANNER_LINK_SELECTOR = `.${BANNER_CLASS}__link`;
 
 module.exports = function ({ config={}, guruResult, customSetup }={}) {
 	let banner;

--- a/src/client/top-slot.js
+++ b/src/client/top-slot.js
@@ -3,8 +3,8 @@ const { messageEvent, listen } = require('./utils');
 
 const ALERT_BANNER_CLASS = 'n-alert-banner';
 const ALERT_ACTION_SELECTOR = '[data-n-messaging-alert-banner-action]';
-const ALERT_BANNER_BUTTON_SELECTOR = '.n-alert-banner__button';
-const ALERT_BANNER_LINK_SELECTOR = '.n-alert-banner__link';
+const ALERT_BANNER_BUTTON_SELECTOR = `.${ALERT_BANNER_CLASS}__button`;
+const ALERT_BANNER_LINK_SELECTOR = `.${ALERT_BANNER_CLASS}__link`;
 
 module.exports = function ({ config={}, guruResult, customSetup }={}) {
 	let alertBanner;

--- a/src/components/anon-subscribe-now-teal/main.scss
+++ b/src/components/anon-subscribe-now-teal/main.scss
@@ -1,14 +1,18 @@
 .n-alert-banner--marketing-anon-subscribe {
 	display: none;
+
 	@include oGridRespondTo('M') {
 		display: block;
 	}
+
 	.n-alert-banner__outer {
 		height: 56px;
 	}
+
 	.n-alert-banner__inner {
 		display: table;
 	}
+
 	.n-alert-banner__actions {
 		height: 56px;
 		max-width: 740px;
@@ -19,12 +23,15 @@
 		display: table-cell;
 		vertical-align: middle;
 	}
+
 	.n-alert-banner__action {
 		padding-right: 0;
 	}
+
 	.n-alert-banner__button {
 		line-height: 14px;
 	}
+
 	.n-alert-banner__actions--clickarea {
 		cursor: pointer;
 	}

--- a/src/components/desktop-app-banner/main.scss
+++ b/src/components/desktop-app-banner/main.scss
@@ -1,9 +1,3 @@
-@import "o-icons/main";
-@import "o-colors/main";
-@import "o-typography/main";
-
-$white: oColorsGetPaletteColor('white');
-
 .n-app-banner__device {
 	left: 90px;
 	margin-top: 95px;
@@ -36,7 +30,7 @@ button {
 	position: relative;
 
 	&::before {
-		@include oIconsGetIcon('tick', $white, 25, $iconset-version: 1);
+		@include oIconsGetIcon('tick', getColor('white'), 25, $iconset-version: 1);
 		display: inline-block;
 		content: '';
 		left: 0;

--- a/src/components/desktop-app-banner/main.scss
+++ b/src/components/desktop-app-banner/main.scss
@@ -30,7 +30,7 @@ button {
 	position: relative;
 
 	&::before {
-		@include oIconsGetIcon('tick', getColor('white'), 25, $iconset-version: 1);
+		@include oIconsGetIcon('tick', oColorsGetPaletteColor('white'), 25, $iconset-version: 1);
 		display: inline-block;
 		content: '';
 		left: 0;

--- a/src/components/invite-colleagues/main.scss
+++ b/src/components/invite-colleagues/main.scss
@@ -6,7 +6,7 @@
 @include oShareActionIcon(mail, invite-colleagues-o-share);
 
 .invite-colleagues__outer {
-	background: getColor('wheat');
+	background: oColorsGetPaletteColor('wheat');
 	text-align: center;
 }
 
@@ -44,12 +44,12 @@
 	&.copy-success {
 		.invite-colleagues__copy-input {
 			&::after {
-				@include oIconsGetIcon('tick', getColor('jade'), 24);
-				color: getColor('jade');
+				@include oIconsGetIcon('tick', oColorsGetPaletteColor('jade'), 24);
+				color: oColorsGetPaletteColor('jade');
 				width: auto;
 				height: 35px;
 				line-height: 35px;
-				background-color: getColor('white');
+				background-color: oColorsGetPaletteColor('white');
 				display: block;
 				position: absolute;
 				top: 50%;
@@ -64,7 +64,7 @@
 		}
 
 		.invite-colleagues__copy-link {
-			border-color: getColor('jade');
+			border-color: oColorsGetPaletteColor('jade');
 		}
 	}
 }
@@ -79,7 +79,7 @@
 		width: auto;
 		height: 35px;
 		line-height: 35px;
-		background: linear-gradient(to left, getColor('white'), transparent);
+		background: linear-gradient(to left, oColorsGetPaletteColor('white'), transparent);
 		display: block;
 		position: absolute;
 		top: 50%;
@@ -92,8 +92,8 @@
 .invite-colleagues__copy-link {
 	@include oTypographySans($scale: 0);
 	position: relative;
-	color: getColor('black-30');
-	background: getColor('white');
+	color: oColorsGetPaletteColor('black-30');
+	background: oColorsGetPaletteColor('white');
 	border: 1px solid;
 	border-right-width: 0;
 	margin: 12px 0;
@@ -114,10 +114,10 @@
 
 .invite-colleagues__copy-text {
 	@include oTypographySansBold($scale: 0);
-	background: getColor('white');
-	border: 1px solid getColor('black-30');
+	background: oColorsGetPaletteColor('white');
+	border: 1px solid oColorsGetPaletteColor('black-30');
 	border-left: 0;
-	color: getColor('black-80');
+	color: oColorsGetPaletteColor('black-80');
 	display: inline-block;
 	padding: 11px 20px;
 	margin: 12px 0;
@@ -163,9 +163,9 @@
 .invite-colleagues-banner__wrapper {
 	.invite-colleagues__copy-link-button {
 		@include oButtonsTheme(inverse);
-		background-color: getColor('black');
-		color: getColor('white');
-		border: getColor('black');
+		background-color: oColorsGetPaletteColor('black');
+		color: oColorsGetPaletteColor('white');
+		border: oColorsGetPaletteColor('black');
 		@include oGridRespondTo($until: M) {
 			margin-bottom: 12px;
 		}

--- a/src/components/invite-colleagues/main.scss
+++ b/src/components/invite-colleagues/main.scss
@@ -1,12 +1,9 @@
-@import "o-buttons/main";
-@import "o-colors/main";
-@import "o-typography/main";
-@import "o-share/main";
-@import "o-banner/main";
-@include oShareBase(o-share);
-@include oShareActionIcon(facebook, o-share);
-@include oShareActionIcon(linkedin, o-share);
-@include oShareActionIcon(mail, o-share);
+@import 'o-share/main';
+
+@include oShareBase(invite-colleagues-o-share);
+@include oShareActionIcon(facebook, invite-colleagues-o-share);
+@include oShareActionIcon(linkedin, invite-colleagues-o-share);
+@include oShareActionIcon(mail, invite-colleagues-o-share);
 
 .invite-colleagues__outer {
 	background: getColor('wheat');
@@ -156,15 +153,11 @@
 	}
 }
 
-.invite-colleagues__share {
+.invite-colleagues__social {
 	@include oTypographySans($scale: 0);
 	display: flex;
 	justify-content: center;
 	margin: 12px 0;
-}
-
-.invite-colleagues__share-text {
-	padding: 10px 12px 10px 0;
 }
 
 .invite-colleagues-banner__wrapper {
@@ -201,7 +194,7 @@
 			}
 		}
 
-		&.invite-colleagues-banner__share {
+		&.invite-colleagues-banner__social {
 			flex-basis: 100%;
 			@include oGridRespondTo(L) {
 				flex: 1;

--- a/templates/components/n-alert-banner.html
+++ b/templates/components/n-alert-banner.html
@@ -1,6 +1,6 @@
 <div class="n-alert-banner n-alert-banner--closed n-alert-banner--{{theme}}{{#if customClass}} {{customClass}}{{/if}}" data-n-component="n-alert-banner" data-n-messaging-component=""{{#if appendToElement}} data-n-alert-banner-append-to-element="{{appendToElement}}"{{/if}} data-n-alert-banner-auto-open="false" data-n-alert-banner-close-button="{{#if closeButton}}{{closeButton}}{{else}}true{{/if}}" {{#if customDataTrackableBanner}}data-trackable="{{customDataTrackableBanner}}"{{/if}}>
 	<div class="n-alert-banner__outer">
-		<div class="o-grid-container n-alert-banner__inner" data-n-alert-banner-inner="">
+		<div class="n-alert-banner__inner" data-n-alert-banner-inner="">
 			{{#if contentLong}}
 			<!-- Content to display on larger screens -->
 				<div class="n-alert-banner__content n-alert-banner__content--long">

--- a/templates/partials/bottom/b2b-upsell.html
+++ b/templates/partials/bottom/b2b-upsell.html
@@ -15,25 +15,25 @@
 				<button class="invite-colleagues__copy-link-button" data-trackable="copy-link" aria-label="Copy link and share" data-n-messaging-banner-action=""></button>
 			</div>
 		</div>
-		<div class="n-messaging-banner__content invite-colleagues-banner__share">
-			<div class="invite-colleagues__share">
-				<div data-o-component="o-share" class="invite-colleagues o-share">
+		<div class="n-messaging-banner__content invite-colleagues-banner__social">
+			<div class="invite-colleagues__social">
+				<div data-o-component="o-share" class="invite-colleagues invite-colleagues-o-share">
 					<ul>
-						<li class="o-share__action">
-							<a class="o-share__icon o-share__icon--linkedin" rel="noopener" href="https://www.linkedin.com/shareArticle?mini=true&url=https://try.ft.com/{{shortName}}&source=Financial+Times&amp;title={{#if longName}}Join%20the%20FT%20trial%20for%20{{encode longName mode='uriComponent'}}{{else}}Join%20your%20colleagues%20in%20a%20free%20FT%20trial{{/if}}&amp;text=Get%20full%20Premium%20Digital%20access%20to%20the%20FT%E2%80%99s%20expert%20analysis%20and%20commentary.%20Stay%20as%20informed%20as%20your%20colleagues%20and%20join%20the%20trial%20today.&amp;via=FT"
+						<li class="invite-colleagues-o-share__action">
+							<a class="invite-colleagues-o-share__icon invite-colleagues-o-share__icon--linkedin" rel="noopener" href="https://www.linkedin.com/shareArticle?mini=true&url=https://try.ft.com/{{shortName}}&source=Financial+Times&amp;title={{#if longName}}Join%20the%20FT%20trial%20for%20{{encode longName mode='uriComponent'}}{{else}}Join%20your%20colleagues%20in%20a%20free%20FT%20trial{{/if}}&amp;text=Get%20full%20Premium%20Digital%20access%20to%20the%20FT%E2%80%99s%20expert%20analysis%20and%20commentary.%20Stay%20as%20informed%20as%20your%20colleagues%20and%20join%20the%20trial%20today.&amp;via=FT"
 							data-trackable="linkedin" data-n-messaging-banner-action="">
-								<span class="o-share__text">Share on LinkedIn (opens new window)</span>
+								<span class="invite-colleagues-o-share__text">Share on LinkedIn (opens new window)</span>
 							</a>
 						</li>
-						<li class="o-share__action">
-							<a class="o-share__icon o-share__icon--facebook" rel="noopener" href="https://www.facebook.com/sharer.php?u=https://try.ft.com/{{shortName}}"
+						<li class="invite-colleagues-o-share__action">
+							<a class="invite-colleagues-o-share__icon invite-colleagues-o-share__icon--facebook" rel="noopener" href="https://www.facebook.com/sharer.php?u=https://try.ft.com/{{shortName}}"
 							data-trackable="facebook" data-n-messaging-banner-action="">
-								<span class="o-share__text">Share on Facebook (opens new window)</span>
+								<span class="invite-colleagues-o-share__text">Share on Facebook (opens new window)</span>
 							</a>
 						</li>
-						<li class="o-share__action">
-							<a class="o-share__icon o-share__icon--mail" data-trackable="email" href="mailto:?subject={{#if longName}}Join%20the%20FT%20trial%20for%20{{ encode longName mode='uriComponent'}}{{else}}Join%20your%20colleagues%20in%20a%20free%20FT%20trial{{/if}}&body={{#if longName}}{{ encode longName mode='uriComponent'}}%20is%20providing%20its%20employees%20with%20a%20free%20Premium%20trial%20for%20the%20Financial%20Times.{{else}}Join%20your%20colleagues%20in%20a%20free%20FT%20trial.{{/if}}%0D%0A%0D%0AStay%20as%20informed%20as%20your%20colleagues%20and%20join%20the%20trial%20today.%0D%0A%0D%0Ahttp%3A%2F%2Ftry.ft.com%2F{{shortName}}%0D%0A%0D%0AYou%20can%20share%20this%20link%20with%20anyone%20in%20your%20company%2C%20so%20they%20can%20get%20access%20too.%0D%0A%0D%0AYou%20must%20have%20an%20organisation%20email%20address%20to%20take%20part." data-n-messaging-banner-action="">
-								<span class="o-share__text">Mail</span>
+						<li class="invite-colleagues-o-share__action">
+							<a class="invite-colleagues-o-share__icon invite-colleagues-o-share__icon--mail" data-trackable="email" href="mailto:?subject={{#if longName}}Join%20the%20FT%20trial%20for%20{{ encode longName mode='uriComponent'}}{{else}}Join%20your%20colleagues%20in%20a%20free%20FT%20trial{{/if}}&body={{#if longName}}{{ encode longName mode='uriComponent'}}%20is%20providing%20its%20employees%20with%20a%20free%20Premium%20trial%20for%20the%20Financial%20Times.{{else}}Join%20your%20colleagues%20in%20a%20free%20FT%20trial.{{/if}}%0D%0A%0D%0AStay%20as%20informed%20as%20your%20colleagues%20and%20join%20the%20trial%20today.%0D%0A%0D%0Ahttp%3A%2F%2Ftry.ft.com%2F{{shortName}}%0D%0A%0D%0AYou%20can%20share%20this%20link%20with%20anyone%20in%20your%20company%2C%20so%20they%20can%20get%20access%20too.%0D%0A%0D%0AYou%20must%20have%20an%20organisation%20email%20address%20to%20take%20part." data-n-messaging-banner-action="">
+								<span class="invite-colleagues-o-share__text">Mail</span>
 							</a>
 						</li>
 					</ul>


### PR DESCRIPTION
~related: https://github.com/Financial-Times/n-alert-banner/pull/20~
~related: https://github.com/Financial-Times/o-banner/pull/38 going to give the same treatment to `o-banner` and see if origami are happy with it or not.~

The tweaks will ensure that messages render correctly, even if `n-ui-foundations` is not explicitly imported via the app in which `n-messaging-client` is included.

 🐿 v2.6.0