### PR TITLE
Hiding the slot container

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ if ( flags.get('messageSlotBottom') || flags.get('messageSlotTop') ) {
 }
 ```
 
-**note:** CSS could be loaded asyncronously so the ```n-ui-hide``` class is used to stop unstyled content flash, ensure your application has ```n-ui-foundation``` to take advantage of this.
+**note:** CSS could be loaded asyncronously so the ```n-ui-hide``` class is used to stop unstyled content flash, ensure your application has ```n-ui-foundations``` to take advantage of this.
 
 # Development
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ if ( flags.get('messageSlotBottom') || flags.get('messageSlotTop') ) {
 }
 ```
 
+**note:** CSS could be loaded asyncronously so the ```n-ui-hide``` class is used to stop unstyled content flash, ensure your application has ```n-ui-foundation``` to take advantage of this.
 
 # Development
 

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -18,7 +18,13 @@ module.exports = {
 			};
 		});
 		if (messages.length > 0) {
-			Promise.all(messages.map(msg => this.initialiseMessage(msg))).catch(this.handleError);
+			Promise.all(messages.map(msg => this.initialiseMessage(msg)))
+				.then(() => {
+					// to stop unstyled content flash and banner jumping a n-ui-hide class is added to the slot
+					// removing this class so that banners are displayed if open
+					slots.forEach(el => el.classList.remove('n-ui-hide'));
+				})
+				.catch(this.handleError);
 		}
 	},
 	initialiseMessage (config) {

--- a/templates/slot.html
+++ b/templates/slot.html
@@ -1,6 +1,7 @@
 {{#nMessagingPresenter @this type=type flags=@root.flags}}
 	{{#if @nMessagingPresenter.hasMessage}}
 		<div
+			class="n-ui-hide"
 			data-n-messaging-slot="{{type}}"
 			data-n-messaging-name="{{@nMessagingPresenter.data.variant}}"
 			data-n-messaging-flag="{{@nMessagingPresenter.data.flag}}"


### PR DESCRIPTION
**Issue**
The message is shown on the page in the original slot location before being moved to the correct location using the client side JS. This causes an unsightly jump.

**Solution**
Hide the content within the slot ```div```, when the client side JS is initialised it moves the message outside of this ```div``` and is therefore shown. Test by slowing your network connection to a slow 3g.

**Drawbacks**
Messages will now only be shown to people with JS enabled.

 🐿 v2.7.0