### PR TITLE
Add more ad blocking logic

### DIFF
--- a/src/components/ad-blocker-reg-banner/main.js
+++ b/src/components/ad-blocker-reg-banner/main.js
@@ -1,0 +1,18 @@
+const { getCurrentLayout } = require('o-grid');
+
+module.exports = function customSetup (banner, done) {
+    function isDesktop () {
+        return ['L', 'XL'].indexOf(getCurrentLayout()) !== -1;
+    }
+
+    function isVideo () {
+        if (document.querySelector('.content__video')) return true;
+    }
+
+    if (isDesktop () || !isVideo()) {
+        done();
+    } else {
+        done({ skip: true });
+    }
+
+};

--- a/src/components/ad-blocker-sub-banner/main.js
+++ b/src/components/ad-blocker-sub-banner/main.js
@@ -1,7 +1,6 @@
 const { getCurrentLayout } = require('o-grid');
 
 module.exports = function customSetup (banner, done) {
-
 	function isDesktop () {
 		return ['L', 'XL'].indexOf(getCurrentLayout()) !== -1;
 	}
@@ -10,7 +9,7 @@ module.exports = function customSetup (banner, done) {
 		if (document.querySelector('.content__video')) return true;
 	}
 
-	if (isDesktop() && !isVideo()) {
+	if (isDesktop () && !isVideo()) {
 		done();
 	} else {
 		done({ skip: true });

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,9 +1,13 @@
 const inviteColleagues = require('./invite-colleagues/main');
 const appBanner = require('./desktop-app-banner/main');
 const anonSubscribe = require('./anon-subscribe-now-teal/main');
+const adBlockerSubBanner = require('./ad-blocker-sub-banner/main');
+const adBlockerRegBanner = require('./ad-blocker-reg-banner/main');
 
 module.exports = {
 	b2bUpsellBanner: inviteColleagues,
 	appPromotingBanner: appBanner,
-	anonSubscribeNow: anonSubscribe
+	anonSubscribeNow: anonSubscribe,
+	adBlockerSubBanner,
+	adBlockerRegBanner
 };


### PR DESCRIPTION
The ad blocker is now shown via `n-messaging-client` but monitoring is showing that it's being shown more often than the previous implementation. Adding in a bit more logic to better reflect the logic in the previous implementation. 