### PR TITLE
Add an alternative, much smaller main SASS include

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,17 @@ Now you can inject the message "slot" template in the relevant place in your mar
 {{> n-messaging-client/templates/slot type='bottom'}}
 ```
 
-Import `n-messaging-client`'s styles to your main css entry:
+Import `n-messaging-client`'s styles to your main css entry. 
+
+If you're using a message type that is server-rendered, import the critical stylesheet into the 'head' section of your main.scss.
+
+```scss
+/* critical.scss */
+
+@import 'n-messaging-client/critical';
+```
+
+In all cases, whether your messages will be client or server rendered, also include the n-messaging-client/main.scss *outside* the 'head' section of your main.scss, so it will be lazily loaded.
 
 ```scss
 /* main.scss */

--- a/critical.scss
+++ b/critical.scss
@@ -1,0 +1,25 @@
+@import "o-buttons/main";
+@import "o-colors/main";
+@import "o-grid/main";
+@import "o-icons/main";
+@import "o-typography/main";
+
+@import 'n-alert-banner/main';
+@import 'o-banner/main';
+
+@include oFontsInclude(MetricWeb);
+@include oFontsInclude(MetricWeb, $weight: semibold);
+
+@include nAlertBanner($class: 'n-alert-banner', $themes: 'neutral');
+
+// ensure the top n-alert-banner inner content is aligned to page content
+.n-alert-banner__inner {
+	@include oGridContainer();
+}
+
+// set base font
+.n-alert-banner,
+.n-messaging-banner {
+	font-family: sans-serif;
+	font-size: 0.8125em;
+}


### PR DESCRIPTION
This just contains the CSS needed by those message types that can be server-rendered (currently only 'gdprConsent' type
In the consuming app, @import 'n-messaging-client/critical' into the head stylesheet, so it's inlined. Then @import 'n-messaging-client/main' outside the head stylesheet so the full styles are lazily loaded 

This stylesheet outputs only 7Kb of uncompressed CSS vs 47Kb from the existing main stylesheet

 🐿 v2.8.0