### PR TITLE
Migrate to our own category of namespaced events

### DIFF
--- a/src/client/bottom-slot.js
+++ b/src/client/bottom-slot.js
@@ -1,5 +1,5 @@
 const oBanner = require('o-banner');
-const { messageEvent, listen } = require('./utils');
+const { generateMessageEvent, listen } = require('./utils');
 
 const BANNER_CLASS = 'n-messaging-banner';
 const BANNER_ACTION_SELECTOR = '[data-n-messaging-banner-action]';
@@ -8,7 +8,7 @@ const BANNER_LINK_SELECTOR = `.${BANNER_CLASS}__link`;
 
 module.exports = function ({ config={}, guruResult, customSetup }={}) {
 	let banner;
-	const generateEvent = config.id && messageEvent({ messageId: config.id, position: config.position, variant: config.name, flag: config.flag });
+	const trackEventAction = config.id && generateMessageEvent({ messageId: config.id, position: config.position, variant: config.name, flag: config.flag });
 	const declarativeElement = !config.lazy && config.content;
 	const defaults = { bannerClass: BANNER_CLASS, autoOpen: false };
 
@@ -17,8 +17,8 @@ module.exports = function ({ config={}, guruResult, customSetup }={}) {
 	} else if (guruResult && guruResult.renderData) {
 		banner = new oBanner(null, imperativeOptions(guruResult.renderData, defaults));
 	} else {
-		if (guruResult.skip && generateEvent) {
-			document.body.dispatchEvent(generateEvent('skip'));
+		if (guruResult.skip && trackEventAction) {
+			trackEventAction('skip');
 		}
 		return;
 	}
@@ -33,17 +33,17 @@ module.exports = function ({ config={}, guruResult, customSetup }={}) {
 			actions = banner.innerElement.querySelectorAll(BANNER_LINK_SELECTOR);
 		}
 	}
-	listen(banner.bannerElement, 'o.bannerClosed', generateEvent('close'));
-	listen(banner.bannerElement, 'o.bannerOpened', generateEvent('view'));
+	listen(banner.bannerElement, 'o.bannerClosed', () => trackEventAction('close'));
+	listen(banner.bannerElement, 'o.bannerOpened', () => trackEventAction('view'));
 	if (actions && actions.length > 0) {
-		actions.forEach((el) => { listen(el, 'click', generateEvent('act')); });
+		actions.forEach((el) => { listen(el, 'click', () => trackEventAction('act')); });
 	}
 
 	// show banner
 	if (customSetup) {
 		customSetup(banner, ({ skip=false }={}) => {
 			if (skip) {
-				document.body.dispatchEvent(generateEvent('skip'));
+				trackEventAction('skip');
 			} else {
 				banner.open();
 			}

--- a/src/client/top-slot.js
+++ b/src/client/top-slot.js
@@ -1,5 +1,5 @@
 const nAlertBanner = require('n-alert-banner');
-const { messageEvent, listen } = require('./utils');
+const { generateMessageEvent, listen } = require('./utils');
 
 const ALERT_BANNER_CLASS = 'n-alert-banner';
 const ALERT_ACTION_SELECTOR = '[data-n-messaging-alert-banner-action]';
@@ -8,7 +8,7 @@ const ALERT_BANNER_LINK_SELECTOR = `.${ALERT_BANNER_CLASS}__link`;
 
 module.exports = function ({ config={}, guruResult, customSetup }={}) {
 	let alertBanner;
-	const generateEvent = config.id && messageEvent({ messageId: config.id, position: config.position, variant: config.name, flag: config.flag });
+	const trackEventAction = config.id && generateMessageEvent({ messageId: config.id, position: config.position, variant: config.name, flag: config.flag });
 	const declarativeElement = !config.lazy && config.content;
 	const defaults = { alertBannerClass: ALERT_BANNER_CLASS, autoOpen: false };
 
@@ -17,8 +17,8 @@ module.exports = function ({ config={}, guruResult, customSetup }={}) {
 	} else if (guruResult && guruResult.renderData) {
 		alertBanner = new nAlertBanner(null, imperativeOptions(guruResult.renderData, defaults));
 	} else {
-		if (guruResult.skip && generateEvent) {
-			document.body.dispatchEvent(generateEvent('skip'));
+		if (guruResult.skip && trackEventAction) {
+			trackEventAction('skip');
 		}
 		return;
 	}
@@ -34,17 +34,17 @@ module.exports = function ({ config={}, guruResult, customSetup }={}) {
 		}
 	}
 
-	listen(alertBanner.alertBannerElement, 'n.alertBannerClosed', generateEvent('close'));
-	listen(alertBanner.alertBannerElement, 'n.alertBannerOpened', generateEvent('view'));
+	listen(alertBanner.alertBannerElement, 'n.alertBannerClosed', () => trackEventAction('close'));
+	listen(alertBanner.alertBannerElement, 'n.alertBannerOpened', () => trackEventAction('view'));
 	if (actions && actions.length > 0) {
-		actions.forEach((el) => { listen(el, 'click', generateEvent('act')); });
+		actions.forEach((el) => { listen(el, 'click', () => trackEventAction('act')); });
 	}
 
 	//show alertBanner
 	if (customSetup) {
 		customSetup(alertBanner, ({ skip=false }={}) => {
 			if (skip) {
-				document.body.dispatchEvent(generateEvent('skip'));
+				trackEventAction('skip');
 			} else {
 				alertBanner.open();
 			}

--- a/src/client/utils.js
+++ b/src/client/utils.js
@@ -3,26 +3,24 @@ const dispatchEvent = (event) => {
 };
 
 module.exports = {
-	messageEvent: function ({ messageId, position, flag, variant }={}) {
+	generateMessageEvent: function ({ messageId, position, flag, variant }={}) {
 		return function (action) {
-			return new CustomEvent('oTracking.event', {
-				detail: {
-					category: 'component',
-					action: action,
-					messaging: messageId,
-					messaging_position: position,
-					messaging_flag: flag,
-					messaging_variant: variant
-				},
-				bubbles: true
-			});
+			const detail = {
+				category: 'n-messaging',
+				action: action,
+				messaging: messageId,
+				messaging_position: position,
+				messaging_flag: flag,
+				messaging_variant: variant
+			};
+			const messagingEvent = new CustomEvent('oTracking.event', { detail, bubbles: true });
+			dispatchEvent(messagingEvent);
+			/* TODO: remove below fallback event once we port to the above */
+			const oldEvent = new CustomEvent('oTracking.event', { detail: Object.assign({}, detail, { category: 'component' }), bubbles: true });
+			dispatchEvent(oldEvent);
 		};
 	},
-	listen: function (el, ev, message) {
-		if (el) {
-			el.addEventListener(ev, function () {
-				dispatchEvent(message);
-			});
-		}
+	listen: function (el, ev, cb) {
+		if (el) el.addEventListener(ev, cb);
 	}
 };


### PR DESCRIPTION
Fire both existing events and a new type of event so that we can
migrate other parts of the stack without breaking

 🐿 v2.8.0