### PR TITLE
Remove privacy policy styles from main stylesheet as already in critical

### DIFF
--- a/main.scss
+++ b/main.scss
@@ -36,4 +36,3 @@ $o-tooltip-is-silent : false;
 @import './src/components/desktop-app-banner/main';
 @import './src/components/anon-subscribe-now-teal/main';
 @import './src/components/cookie-consent/main';
-@import './src/components/privacy-policy/main';


### PR DESCRIPTION
As the styles were in both critical and main stylesheets, the CSS build was deduping them and leaving only a copy in the (lazily loaded) main stylesheet. As the markup was server-rendered, this was causing a flash of unstyled content.
 
🐿 v2.8.0