### PR TITLE
Small tweak to use the "skip" functionality for cookie banner

### DIFF
--- a/src/components/cookie-consent/main.js
+++ b/src/components/cookie-consent/main.js
@@ -52,6 +52,7 @@ module.exports = function customSetup (banner, done) {
 	};
 
 	if (hasAccepted) {
+		removeBanner();
 		done({ skip: true });
 	} else {
 		setup();

--- a/src/components/cookie-consent/main.js
+++ b/src/components/cookie-consent/main.js
@@ -50,10 +50,12 @@ module.exports = function customSetup (banner, done) {
 			}, 1);
 		}
 	};
+
 	if (hasAccepted) {
-		removeBanner();
+		done({ skip: true });
 	} else {
 		setup();
+		done();
 	}
-	done();
+
 };


### PR DESCRIPTION
Previously if the cookie banner was shown in error, it would
briefly be rendered on the page before being hidden.

This tweaks the done() callback in the cookie custom setup to
return { skip: true } if we do not want to render the message.

This has the benefit of allowing us to track incorrect message
allocataions.

 🐿 v2.8.0