### PR TITLE
Removes the deloitte subscription banner

### DIFF
--- a/manifest.js
+++ b/manifest.js
@@ -48,9 +48,5 @@ module.exports = {
 	tlsDeprecation: {
 		partial: 'top/tls-deprecation',
 		messageId: 'tlsDeprecation'
-	},
-	deloitteSubscription: {
-		partial: 'top/deloitte-subscription',
-		messageId: 'deloitteSubscription'
 	}
 };

--- a/templates/partials/top/deloitte-subscription.html
+++ b/templates/partials/top/deloitte-subscription.html
@@ -1,8 +1,0 @@
-{{> n-messaging-client/templates/components/n-alert-banner
-	theme='error'
-	contentTitle='Deloitte UK has decided not to renew their enterprise subscription to FT.com for all UK staff.'
-	content='From the 31st May you will no longer have full access'
-	linkUrl='https://enterprise.ft.com/en-gb/deloitte-uk-cancellation-notice/'
-	linkLabel='Find out more'
-	closeButton=false
-}}


### PR DESCRIPTION
This banner is no longer being used. 
 🐿 v2.8.0