### PR TITLE
update copy and link on USA sale

### DIFF
--- a/secret-squirrel.js
+++ b/secret-squirrel.js
@@ -6,11 +6,11 @@ module.exports = {
 	strings: {
 		deny: [],
 		denyOverrides: [
-			'27e66825-bc4f-ba59-a3cd-1a8f08579bfe', // templates/partials/top/anon-subscribe-now-teal.html:3|11
-			'a9582121-87c2-09a7-0cc0-4caf594985d5', // popup-prompt/main.js:131
-			'c1773439-53dc-df3d-9acc-20ce2ecde318', // popup-prompt/main.js:133
-			'45e2193a-f479-11e7-8c80-69ca88a9e8d1', // README.md:175
-			'c1b046a6-4b46-dc66-9bed-9f77389b619a' // templates/partial/bottom/usa-sale: 25
+			'45e2193a-f479-11e7-8c80-69ca88a9e8d1', // README.md:204
+			'c1773439-53dc-df3d-9acc-20ce2ecde318', // manifest.js:24
+			'c1b046a6-4b46-dc66-9bed-9f77389b619a', // templates/partials/bottom/usa-sale.html:25
+			'27e66825-bc4f-ba59-a3cd-1a8f08579bfe', // templates/partials/top/anon-subscribe-now-teal.html:3
+			'1c06e610-c7a7-c0fe-3356-e498223688ae' // templates/partials/top/usa-sale.html:3
 		]
 	}
 };

--- a/templates/partials/top/usa-sale.html
+++ b/templates/partials/top/usa-sale.html
@@ -1,8 +1,8 @@
 {{> n-messaging-client/templates/components/n-alert-banner
 	theme='marketing-anon-subscribe'
-	buttonUrl='http://subs.ft.com/spa3_bc9?utm_uk=WWAFL&utm_eu=WWAFM&utm_as=FFIBAX&utm_us=JJIBAF&segmentId=27e66825-bc4f-ba59-a3cd-1a8f08579bfe'
+	buttonUrl='https://subs.ft.com/spa3_bc12?segmentId=1c06e610-c7a7-c0fe-3356-e498223688ae&utm_us=JJIBAL'
 	buttonLabel='Subscribe'
 	closeButton=false
-	contentDetail='<b>Special US offers through July 31 -</b> Print delivery <b>$1.90</b> per week | Standard Digital <b>$2.77</b> per week'
+	contentDetail='<b>Special US offer through August 31 -</b> Print delivery for <b>$1.90</b> per week'
 	customClass='n-alert-banner--marketing-anon-subscribe'
 }}


### PR DESCRIPTION
 🐿 v2.9.0

## Feature Description
Update copy and link for USA sale on top banner

## Link to Ticket / Card:
https://trello.com/c/wdFghfoE

## Screenshots:
![image](https://user-images.githubusercontent.com/17846996/43454113-eae1f31c-94b3-11e8-80ec-206bc03ee7e9.png)

