### PR TITLE
Google button styles

### DIFF
--- a/main.scss
+++ b/main.scss
@@ -3,3 +3,4 @@
 @import './src/components/top/anon-subscribe-now-teal/main';
 @import './src/components/top/team-trial/main';
 @import './src/components/bottom/school-leavers/main';
+@import './src/components/bottom/swg-entitlements-prompt/main';

--- a/src/components/bottom/swg-entitlements-prompt/main.scss
+++ b/src/components/bottom/swg-entitlements-prompt/main.scss
@@ -1,0 +1,23 @@
+.swg-entitlements-prompt__wrapper {
+
+	.n-messaging-banner__action {
+		position: relative;
+	}
+
+	.n-messaging-banner__button {
+		@include oButtons;
+		@include oButtonsSize('big');
+		@include oButtonsTheme('secondary');
+		background-color: oColorsGetPaletteColor('white');
+		padding-left: 40px;
+
+		&:before {
+			content: '';
+			background: transparent url('https://www.ft.com/__origami/service/image/v2/images/raw/https%3A%2F%2Fwww.ft.com%2F__assets%2Fcreatives%2FG_active_focused_pressed.svg?source=m-login&width=20&height=20&format=svg') no-repeat;
+			position: absolute;
+			left: 10px;
+			width: 18px;
+			height: 18px;
+		}
+	}
+}

--- a/templates/partials/bottom/swg-entitlements-prompt.html
+++ b/templates/partials/bottom/swg-entitlements-prompt.html
@@ -1,14 +1,16 @@
-{{> n-messaging-client/templates/components/n-messaging-banner
-themeMarketing='true'
-small='true'
-contentLong = '
-	<h3>You\'ve got a subscription on FT.com</h3>
-	<p>It looks like you are already subscribed to FT.com via Google</p>
-'
-contentShort = '
-<h3>You\'ve got a subscription on FT.com</h3>
-<p>It looks like you are already subscribed to FT.com via Google</p>
-'
-buttonLabel = 'Sign In'
-buttonUrl = 'https://accounts.ft.com/login'
-}}
+<div class="swg-entitlements-prompt__wrapper">
+	{{> n-messaging-client/templates/components/n-messaging-banner
+		themeMarketing='true'
+		small='true'
+		contentLong = '
+			<h3>You\'ve got a subscription on FT.com</h3>
+			<p>It looks like you are already subscribed to FT.com via Google</p>
+		'
+		contentShort = '
+		<h3>You\'ve got a subscription on FT.com</h3>
+		<p>It looks like you are already subscribed to FT.com via Google</p>
+		'
+		buttonLabel = 'Sign In'
+		buttonUrl = 'https://accounts.ft.com/login'
+	}}
+</div>


### PR DESCRIPTION
Slight different from the design in https://trello.com/c/WCQm5hVx/587-add-siwg-button-styling-to-swg-entitlements-banner but closer to o-button.

| Before | After |
| --- | --- |
| <img width="646" alt="screen shot 2018-09-06 at 14 01 50" src="https://user-images.githubusercontent.com/1721150/45158983-71cdc680-b1dd-11e8-830a-11e7550294b0.png"> | <img width="660" alt="screen shot 2018-09-06 at 14 01 01" src="https://user-images.githubusercontent.com/1721150/45158995-77c3a780-b1dd-11e8-8d7d-c041ac4d5fdb.png"> |

