### PR TITLE
dynamically generate list of messages for testing

### DIFF
--- a/test/smoke.js
+++ b/test/smoke.js
@@ -1,21 +1,18 @@
 const manifest = require('../manifest');
 
-let messages = [];
-
 const parseSlot = (path) => {
 	if (path.includes('bottom')) return 'messageSlotBottom';
 	if (path.includes('top')) return 'messageSlotTop';
 };
 
 // create array of feature names and slots based on manifest
-for (let key in manifest) {
-	if (manifest.hasOwnProperty(key)) {
-		messages.push({
-			name: key,
-			slot: parseSlot(manifest[key]['path'])
-		});
-	}
-}
+const createMessage = function (key) {
+	return {
+		name: key,
+		slot: parseSlot(manifest[key].path)
+	};
+};
+const messages = Object.keys(manifest).map(createMessage);
 
 const messageSlotTests = messages.map(message => {
 	return {

--- a/test/smoke.js
+++ b/test/smoke.js
@@ -6,23 +6,17 @@ const parseSlot = (path) => {
 };
 
 // create array of feature names and slots based on manifest
-const createMessage = function (key) {
-	return {
-		name: key,
-		slot: parseSlot(manifest[key].path)
-	};
-};
-const messages = Object.keys(manifest).map(createMessage);
-
-const messageSlotTests = messages.map(message => {
+const createMessage = (key) => {
+	const slotName = parseSlot(manifest[key].path);
 	return {
 		headers: {
-			'FT-Flags': `${message.slot}:${message.name}`
+			'FT-Flags': `${slotName}:${key}`
 		},
 		urls: {
-			[`/${message.slot}-${message.name}`]: 200 // url is irrelevant mainly to help debug
+			[`/${slotName}-${key}`]: 200 // url is irrelevant mainly to help debug
 		}
 	};
-});
+};
+const messageSlotTests = Object.keys(manifest).map(createMessage);
 
 module.exports = messageSlotTests;

--- a/test/smoke.js
+++ b/test/smoke.js
@@ -5,8 +5,8 @@ const parseSlot = (path) => {
 	if (path.includes('top')) return 'messageSlotTop';
 };
 
-// create array of feature names and slots based on manifest
-const createMessage = (key) => {
+// create array for pa11y, with url and FT flag setting for each message
+const createTest = (key) => {
 	const slotName = parseSlot(manifest[key].path);
 	return {
 		headers: {
@@ -17,6 +17,6 @@ const createMessage = (key) => {
 		}
 	};
 };
-const messageSlotTests = Object.keys(manifest).map(createMessage);
+const messageSlotTests = Object.keys(manifest).map(createTest);
 
 module.exports = messageSlotTests;

--- a/test/smoke.js
+++ b/test/smoke.js
@@ -1,29 +1,21 @@
-const messages = [
-	{
-		name: 'b2bUpsellBanner',
-		slot: 'messageSlotBottom'
-	},
-	{
-		name: 'appPromotingBanner',
-		slot: 'messageSlotBottom'
-	},
-	{
-		name: 'cookieConsent',
-		slot: 'messageSlotBottom'
-	},
-	{
-		name: 'paymentFailure',
-		slot: 'messageSlotTop'
-	},
-	{
-		name: 'anonSubscribeNow',
-		slot: 'messageSlotTop'
-	},
-	{
-		name: 'swgEntitlementsPrompt',
-		slot: 'messageSlotBottom'
+const manifest = require('../manifest');
+
+let messages = [];
+
+const parseSlot = (path) => {
+	if (path.includes('bottom')) return 'messageSlotBottom';
+	if (path.includes('top')) return 'messageSlotTop';
+};
+
+// create array of feature names and slots based on manifest
+for (let key in manifest) {
+	if (manifest.hasOwnProperty(key)) {
+		messages.push({
+			name: key,
+			slot: parseSlot(manifest[key]['path'])
+		});
 	}
-];
+}
 
 const messageSlotTests = messages.map(message => {
 	return {


### PR DESCRIPTION
 🐿 v2.10.3

Whilst yak-shaving on another issue on this repo yesterday i noticed the list of features for pa11y testing was hardcoded. As this list changes pretty frequently and the tests are somewhat tucked away (i.e. easy to forget to update) I thought it would be better to generate the list dynamically from the manifest which _should_ be representative of reality