### PR TITLE
Fix cookie banner link style

### DIFF
--- a/src/components/bottom/cookie-consent/main.scss
+++ b/src/components/bottom/cookie-consent/main.scss
@@ -57,7 +57,6 @@
 
 	.cookie-banner__link--external {
 		@include oTypographyLinkExternal;
-		margin-right: $spacing-unit; /* override 24px margin from origami mixin */
 	}
 
 	.cookie-banner__link,
@@ -89,7 +88,6 @@
 
 		.cookie-banner__link--external {
 			@include oTypographyLinkExternal;
-			margin-right: $spacing-unit; /* override 24px margin from origami mixin */
 		}
 
 		.cookie-banner__link,


### PR DESCRIPTION
 🐿 v2.10.3
The "cookies" link in the cookie banner had the wrong right padding 