### PR TITLE
Tackles errors in sentry

### DIFF
--- a/src/client/bottom-slot.js
+++ b/src/client/bottom-slot.js
@@ -17,7 +17,7 @@ module.exports = function ({ config={}, guruResult, customSetup }={}) {
 	} else if (guruResult && guruResult.renderData) {
 		banner = new oBanner(null, imperativeOptions(guruResult.renderData, { bannerClass: BANNER_CLASS, autoOpen: false }));
 	} else {
-		if (guruResult.skip && trackEventAction) {
+		if (guruResult && guruResult.skip && trackEventAction) {
 			trackEventAction('skip');
 		}
 		return;
@@ -58,7 +58,7 @@ module.exports = function ({ config={}, guruResult, customSetup }={}) {
 
 };
 
-function imperativeOptions (opts, defaults) {
+function imperativeOptions (opts = {}, defaults = {}) {
 	return {
 		autoOpen: opts.autoOpen || defaults.autoOpen,
 		suppressCloseButton: opts.suppressCloseButton || false,


### PR DESCRIPTION
Tackles errors seen in sentry in cases where `guruResult` doesn't exist or no arguments are passed to `imperativeOptions()`
 🐿 v2.10.2