### PR TITLE
Tech Scroll Asia

### DIFF
--- a/main.scss
+++ b/main.scss
@@ -4,3 +4,4 @@
 @import './src/components/top/anon-subscribe-now/main';
 @import './src/components/bottom/team-trial/main';
 @import './src/components/bottom/brexit/main';
+@import './src/components/bottom/tech-scroll-asia/main';

--- a/manifest.js
+++ b/manifest.js
@@ -57,5 +57,8 @@ module.exports = {
 	},
 	brexitCampaign: {
 		path: 'bottom/brexit'
-	}
+	},
+	techScrollAsia: {
+		path: 'bottom/tech-scroll-asia'
+	},
 };

--- a/src/components/bottom/tech-scroll-asia/main.scss
+++ b/src/components/bottom/tech-scroll-asia/main.scss
@@ -1,7 +1,7 @@
 .variant-techScrollAsia {
 	.n-messaging-banner--compact .n-messaging-banner__inner {
 		background-color: #003B71;
-		background-image: url("https://trello-attachments.s3.amazonaws.com/5b3b4d9496e584bfc489978a/5c9dfee3acb67a57f43664d1/afa1adb912e6a326503b203a1d3eaa66/graphic-element.png");
+		background-image: url("https://www.ft.com/__origami/service/image/v2/images/raw/https%3A%2F%2Fs3-eu-west-1.amazonaws.com%2Fenvoy-tsa%2Ftsabg.png?source=ip-envoy&width=236&height=450");
 		background-size: contain;
 		background-repeat: no-repeat;
 		background-position-x: right;

--- a/src/components/bottom/tech-scroll-asia/main.scss
+++ b/src/components/bottom/tech-scroll-asia/main.scss
@@ -1,0 +1,34 @@
+.variant-techScrollAsia {
+	.n-messaging-banner--compact .n-messaging-banner__inner {
+        background-color: #003B71;
+        background-image: url("https://trello-attachments.s3.amazonaws.com/5b3b4d9496e584bfc489978a/5c9dfee3acb67a57f43664d1/afa1adb912e6a326503b203a1d3eaa66/graphic-element.png");
+        background-size: contain;
+        background-repeat: no-repeat;
+        background-position-x: right;
+		// position: relative;
+        // overflow: hidden;
+        color: white;
+    }
+    
+    .n-messaging-banner__close {
+        background-image: url("https://www.ft.com/__origami/service/image/v2/images/raw/fticon-v1:cross?source=o-icons&tint=%23ffffff,%23ffffff&format=svg");
+    }
+
+	.n-messaging-banner__heading:after {
+		margin-top: 8px;
+        margin-bottom: 16px;
+        content: '';
+        display: block;
+        width: 100px;
+        border-bottom: 8px solid;
+        border-color: #295B88;
+	}
+
+    .n-messaging-banner--compact .n-messaging-banner__button {
+		@include oButtonsTheme($theme: (background: (#3A70AF), accent: 'white', colorizer: 'primary'));
+    }
+    
+    .n-messaging-banner--compact .n-messaging-banner__button {
+        color: black;
+    }
+}

--- a/src/components/bottom/tech-scroll-asia/main.scss
+++ b/src/components/bottom/tech-scroll-asia/main.scss
@@ -1,50 +1,36 @@
 .variant-techScrollAsia {
 	.n-messaging-banner--compact .n-messaging-banner__inner {
-        background-color: #003B71;
-        background-image: url("https://trello-attachments.s3.amazonaws.com/5b3b4d9496e584bfc489978a/5c9dfee3acb67a57f43664d1/afa1adb912e6a326503b203a1d3eaa66/graphic-element.png");
-        background-size: contain;
-        background-repeat: no-repeat;
-        background-position-x: right;
-		// position: relative;
-        // overflow: hidden;
-        color: white;
+		background-color: #003B71;
+		background-image: url("https://trello-attachments.s3.amazonaws.com/5b3b4d9496e584bfc489978a/5c9dfee3acb67a57f43664d1/afa1adb912e6a326503b203a1d3eaa66/graphic-element.png");
+		background-size: contain;
+		background-repeat: no-repeat;
+		background-position-x: right;
+		color: white;
+	}
 
-        // &:after {
-        //     @include oGridRespondTo(M) {
-        //         position: absolute;
-        //         content: "";
-        //         background-image: url("https://trello-attachments.s3.amazonaws.com/5b3b4d9496e584bfc489978a/5c9dfee3acb67a57f43664d1/afa1adb912e6a326503b203a1d3eaa66/graphic-element.png");
-        //         height: 330px;
-		// 		background-repeat: no-repeat;
-		// 		top: 79px;
-		// 		left: 273px;
-        //     }
-        // }
-    }
-    
-    .n-messaging-banner__close {
-        background-image: url("https://www.ft.com/__origami/service/image/v2/images/raw/fticon-v1:cross?source=o-icons&tint=%23ffffff,%23ffffff&format=svg");
-    }
+	.n-messaging-banner__close {
+		background-image: url("https://www.ft.com/__origami/service/image/v2/images/raw/fticon-v1:cross?source=o-icons&tint=%23ffffff,%23ffffff&format=svg");
+	}
 
 	.n-messaging-banner__heading:after {
 		margin-top: 8px;
-        margin-bottom: 16px;
-        content: '';
-        display: block;
-        width: 100px;
-        border-bottom: 8px solid;
-        border-color: #295B88;
-    }
-    
-    .n-messaging-banner__content p {
+		margin-bottom: 16px;
+		content: '';
+		display: block;
+		width: 100px;
+		border-bottom: 8px solid;
+		border-color: #295B88;
+	}
+
+	.n-messaging-banner__content p {
 		padding-right: 40px;
 	}
 
-    .n-messaging-banner--compact .n-messaging-banner__button {
+	.n-messaging-banner--compact .n-messaging-banner__button {
 		@include oButtonsTheme($theme: (background: (#3A70AF), accent: 'white', colorizer: 'primary'));
-    }
-    
-    .n-messaging-banner--compact .n-messaging-banner__button {
-        color: black;
-    }
+	}
+
+	.n-messaging-banner--compact .n-messaging-banner__button {
+		color: black;
+	}
 }

--- a/src/components/bottom/tech-scroll-asia/main.scss
+++ b/src/components/bottom/tech-scroll-asia/main.scss
@@ -8,6 +8,18 @@
 		// position: relative;
         // overflow: hidden;
         color: white;
+
+        // &:after {
+        //     @include oGridRespondTo(M) {
+        //         position: absolute;
+        //         content: "";
+        //         background-image: url("https://trello-attachments.s3.amazonaws.com/5b3b4d9496e584bfc489978a/5c9dfee3acb67a57f43664d1/afa1adb912e6a326503b203a1d3eaa66/graphic-element.png");
+        //         height: 330px;
+		// 		background-repeat: no-repeat;
+		// 		top: 79px;
+		// 		left: 273px;
+        //     }
+        // }
     }
     
     .n-messaging-banner__close {
@@ -22,6 +34,10 @@
         width: 100px;
         border-bottom: 8px solid;
         border-color: #295B88;
+    }
+    
+    .n-messaging-banner__content p {
+		padding-right: 40px;
 	}
 
     .n-messaging-banner--compact .n-messaging-banner__button {

--- a/templates/components/n-messaging-banner.html
+++ b/templates/components/n-messaging-banner.html
@@ -2,6 +2,7 @@
 	{{#unless renderOpen}}n-messaging-banner--closed{{/unless}}
 	{{#if themeMarketing}} n-messaging-banner--marketing{{/if}}
 	{{#if themeProduct}} n-messaging-banner--product{{/if}}
+	{{#if themeCompact}} n-messaging-banner--compact{{/if}}
 	{{#if small}} n-messaging-banner--small{{/if}}"
 	data-o-component="n-messaging-banner"
 	data-n-messaging-component=""

--- a/templates/partials/bottom/tech-scroll-asia.html
+++ b/templates/partials/bottom/tech-scroll-asia.html
@@ -1,20 +1,21 @@
 <div class="n-messaging-banner variant-{{@nMessagingPresenter.data.variant}}">
-            {{#> n-messaging-client/templates/components/n-messaging-banner
-                themeCompact=true
-                renderOpen=true
-            }}
-            <div class="n-messaging-banner__inner" data-o-banner-inner="" data-n-messaging-banner-inner="">			
-                <div class="n-messaging-banner__content">
-				<header class="n-messaging-banner__heading">
-					<h1>Introducing Tech Scroll Asia</h1>
-				</header>
-				<p>Your briefing on the billions being made & lost in the world of Asia Tech, sent weekly to your inbox.</p>
+	{{#> n-messaging-client/templates/components/n-messaging-banner
+		themeCompact=true
+		renderOpen=true
+	}}
+	<div class="n-messaging-banner__inner" data-o-banner-inner="" data-n-messaging-banner-inner="">
+		<div class="n-messaging-banner__content">
+			<header class="n-messaging-banner__heading">
+				<h1>Introducing Tech Scroll Asia</h1>
+			</header>
+			<p>Your briefing on the billions being made & lost in the world of Asia Tech, sent weekly to your inbox.</p>
+		</div>
+		<div class="n-messaging-banner__actions">
+			<div class="n-messaging-banner__action">
+				<a href="https://ep.ft.com/newsletters/5c8b92df81ab3b00044a2110/subscribe"
+					class="n-messaging-banner__button">Subscribe</a>
 			</div>
-			<div class="n-messaging-banner__actions">
-				<div class="n-messaging-banner__action">
-					<a href="https://ep.ft.com/newsletters/5c8b92df81ab3b00044a2110/subscribe" class="n-messaging-banner__button">Subscribe</a>
-				</div>
-			</div>
-        </div>
-        {{/n-messaging-client/templates/components/n-messaging-banner}}
+		</div>
+	</div>
+	{{/n-messaging-client/templates/components/n-messaging-banner}}
 </div>

--- a/templates/partials/bottom/tech-scroll-asia.html
+++ b/templates/partials/bottom/tech-scroll-asia.html
@@ -1,0 +1,20 @@
+<div class="n-messaging-banner variant-{{@nMessagingPresenter.data.variant}}">
+            {{#> n-messaging-client/templates/components/n-messaging-banner
+                themeCompact=true
+                renderOpen=true
+            }}
+            <div class="n-messaging-banner__inner" data-o-banner-inner="" data-n-messaging-banner-inner="">			
+                <div class="n-messaging-banner__content">
+				<header class="n-messaging-banner__heading">
+					<h1>Introducing Tech Scroll Asia</h1>
+				</header>
+				<p>Your briefing on the billions being made & lost in the world of Asia Tech, sent weekly to your inbox.</p>
+			</div>
+			<div class="n-messaging-banner__actions">
+				<div class="n-messaging-banner__action">
+					<a href="https://ep.ft.com/newsletters/5c8b92df81ab3b00044a2110/subscribe" class="n-messaging-banner__button">Subscribe</a>
+				</div>
+			</div>
+        </div>
+        {{/n-messaging-client/templates/components/n-messaging-banner}}
+</div>


### PR DESCRIPTION
Envoy is working with the Conversion team to create an on-site message to promote the new newsletter with Nikkei, Tech Scroll Asia.

I've added the on-site message for the bottom slot according to other OSMs found in the repo: adding the HTML, the SCSS, and putting the name on the manifest.

I've also added the `compact` theme from `o-banner` which can now be used for future OSMs in `n-messaging-client`.

Please let me know if there are any questions or changes that need to be made.