### PR TITLE
Removes classes .variant-brexitCampaign and variant-techScrollAsia

### DIFF
--- a/src/components/bottom/brexit/main.scss
+++ b/src/components/bottom/brexit/main.scss
@@ -1,33 +1,31 @@
-.variant-brexitCampaign {
-	.n-messaging-banner--product.n-messaging-banner--small .n-messaging-banner__inner {
-		background-color: oColorsGetPaletteColor('oxford-30');
-		position: relative;
-		overflow: hidden;
+.n-messaging-banner--product.n-messaging-banner--small .n-messaging-banner__inner {
+	background-color: oColorsGetPaletteColor('oxford-30');
+	position: relative;
+	overflow: hidden;
 
-		&:after {
-			@include oGridRespondTo(M) {
-				position: absolute;
-				content: "";
-				background-image: url(https://www.ft.com/__origami/service/image/v2/images/raw/ftlogo-v1:brand-brexit?source=origami-registry&width=430);
-				height: 330px;
-				width: 430px;
-				background-repeat: no-repeat;
-				top: 79px;
-				left: 273px;
-			}
+	&:after {
+		@include oGridRespondTo(M) {
+			position: absolute;
+			content: "";
+			background-image: url(https://www.ft.com/__origami/service/image/v2/images/raw/ftlogo-v1:brand-brexit?source=origami-registry&width=430);
+			height: 330px;
+			width: 430px;
+			background-repeat: no-repeat;
+			top: 79px;
+			left: 273px;
 		}
 	}
+}
 
-	.n-messaging-banner__heading:after {
-		content: none;
-	}
+.n-messaging-banner__inner .n-messaging-banner__heading:after {
+	content: none;
+}
 
-	// to wrap content text so that it doesn't get hidden behind the flag image
-	.n-messaging-banner__content span {
-		display: inline-block;
-	}
+// to wrap content text so that it doesn't get hidden behind the flag image
+.n-messaging-banner__content span {
+	display: inline-block;
+}
 
-	.n-messaging-banner--product .n-messaging-banner__button {
-		@include oButtonsTheme($theme: (background: 'oxford-30', accent: 'white', colorizer: 'primary'));
-	}
+.n-messaging-banner--product .n-messaging-banner__button {
+	@include oButtonsTheme($theme: (background: 'oxford-30', accent: 'white', colorizer: 'primary'));
 }

--- a/src/components/bottom/brexit/main.scss
+++ b/src/components/bottom/brexit/main.scss
@@ -1,31 +1,33 @@
-.n-messaging-banner--product.n-messaging-banner--small .n-messaging-banner__inner {
-	background-color: oColorsGetPaletteColor('oxford-30');
-	position: relative;
-	overflow: hidden;
+.n-messaging-banner--brexit {
+	.n-messaging-banner--product.n-messaging-banner--small .n-messaging-banner__inner {
+		background-color: oColorsGetPaletteColor('oxford-30');
+		position: relative;
+		overflow: hidden;
 
-	&:after {
-		@include oGridRespondTo(M) {
-			position: absolute;
-			content: "";
-			background-image: url(https://www.ft.com/__origami/service/image/v2/images/raw/ftlogo-v1:brand-brexit?source=origami-registry&width=430);
-			height: 330px;
-			width: 430px;
-			background-repeat: no-repeat;
-			top: 79px;
-			left: 273px;
+		&:after {
+			@include oGridRespondTo(M) {
+				position: absolute;
+				content: "";
+				background-image: url(https://www.ft.com/__origami/service/image/v2/images/raw/ftlogo-v1:brand-brexit?source=origami-registry&width=430);
+				height: 330px;
+				width: 430px;
+				background-repeat: no-repeat;
+				top: 79px;
+				left: 273px;
+			}
 		}
 	}
-}
 
-.n-messaging-banner__inner .n-messaging-banner__heading:after {
-	content: none;
-}
+	.n-messaging-banner__heading:after {
+		content: none;
+	}
 
-// to wrap content text so that it doesn't get hidden behind the flag image
-.n-messaging-banner__content span {
-	display: inline-block;
-}
+	// to wrap content text so that it doesn't get hidden behind the flag image
+	.n-messaging-banner__content span {
+		display: inline-block;
+	}
 
-.n-messaging-banner--product .n-messaging-banner__button {
-	@include oButtonsTheme($theme: (background: 'oxford-30', accent: 'white', colorizer: 'primary'));
+	.n-messaging-banner__button {
+		@include oButtonsTheme($theme: (background: 'oxford-30', accent: 'white', colorizer: 'primary'));
+	}
 }

--- a/src/components/bottom/tech-scroll-asia/main.scss
+++ b/src/components/bottom/tech-scroll-asia/main.scss
@@ -1,34 +1,36 @@
-.n-messaging-banner--compact .n-messaging-banner__inner {
-	background-color: #003B71;
-	background-image: url("https://www.ft.com/__origami/service/image/v2/images/raw/https%3A%2F%2Fs3-eu-west-1.amazonaws.com%2Fenvoy-tsa%2Ftsabg.png?source=ip-envoy&width=236&height=450");
-	background-size: contain;
-	background-repeat: no-repeat;
-	background-position-x: right;
-	color: white;
-}
+.n-messaging-banner--tech-scroll-asia {
+	.n-messaging-banner__inner {
+		background-color: #003B71;
+		background-image: url("https://www.ft.com/__origami/service/image/v2/images/raw/https%3A%2F%2Fs3-eu-west-1.amazonaws.com%2Fenvoy-tsa%2Ftsabg.png?source=ip-envoy&width=236&height=450");
+		background-size: contain;
+		background-repeat: no-repeat;
+		background-position-x: right;
+		color: white;
+	}
 
-.n-messaging-banner__close {
-	background-image: url("https://www.ft.com/__origami/service/image/v2/images/raw/fticon-v1:cross?source=o-icons&tint=%23ffffff,%23ffffff&format=svg");
-}
+	.n-messaging-banner__close {
+		background-image: url("https://www.ft.com/__origami/service/image/v2/images/raw/fticon-v1:cross?source=o-icons&tint=%23ffffff,%23ffffff&format=svg");
+	}
 
-.n-messaging-banner__content .n-messaging-banner__heading:after {
-	margin-top: 8px;
-	margin-bottom: 16px;
-	content: '';
-	display: block;
-	width: 100px;
-	border-bottom: 8px solid;
-	border-color: #295B88;
-}
+	.n-messaging-banner__heading:after {
+		margin-top: 8px;
+		margin-bottom: 16px;
+		content: '';
+		display: block;
+		width: 100px;
+		border-bottom: 8px solid;
+		border-color: #295B88;
+	}
 
-.n-messaging-banner__content p {
-	padding-right: 40px;
-}
+	.n-messaging-banner__content p {
+		padding-right: 40px;
+	}
 
-.n-messaging-banner--compact .n-messaging-banner__button {
-	@include oButtonsTheme($theme: (background: (#3A70AF), accent: 'white', colorizer: 'primary'));
-}
+	.n-messaging-banner__button {
+		@include oButtonsTheme($theme: (background: (#3A70AF), accent: 'white', colorizer: 'primary'));
+	}
 
-.n-messaging-banner--compact .n-messaging-banner__button {
-	color: black;
+	.n-messaging-banner__button {
+		color: black;
+	}
 }

--- a/src/components/bottom/tech-scroll-asia/main.scss
+++ b/src/components/bottom/tech-scroll-asia/main.scss
@@ -1,36 +1,34 @@
-.variant-techScrollAsia {
-	.n-messaging-banner--compact .n-messaging-banner__inner {
-		background-color: #003B71;
-		background-image: url("https://www.ft.com/__origami/service/image/v2/images/raw/https%3A%2F%2Fs3-eu-west-1.amazonaws.com%2Fenvoy-tsa%2Ftsabg.png?source=ip-envoy&width=236&height=450");
-		background-size: contain;
-		background-repeat: no-repeat;
-		background-position-x: right;
-		color: white;
-	}
+.n-messaging-banner--compact .n-messaging-banner__inner {
+	background-color: #003B71;
+	background-image: url("https://www.ft.com/__origami/service/image/v2/images/raw/https%3A%2F%2Fs3-eu-west-1.amazonaws.com%2Fenvoy-tsa%2Ftsabg.png?source=ip-envoy&width=236&height=450");
+	background-size: contain;
+	background-repeat: no-repeat;
+	background-position-x: right;
+	color: white;
+}
 
-	.n-messaging-banner__close {
-		background-image: url("https://www.ft.com/__origami/service/image/v2/images/raw/fticon-v1:cross?source=o-icons&tint=%23ffffff,%23ffffff&format=svg");
-	}
+.n-messaging-banner__close {
+	background-image: url("https://www.ft.com/__origami/service/image/v2/images/raw/fticon-v1:cross?source=o-icons&tint=%23ffffff,%23ffffff&format=svg");
+}
 
-	.n-messaging-banner__heading:after {
-		margin-top: 8px;
-		margin-bottom: 16px;
-		content: '';
-		display: block;
-		width: 100px;
-		border-bottom: 8px solid;
-		border-color: #295B88;
-	}
+.n-messaging-banner__content .n-messaging-banner__heading:after {
+	margin-top: 8px;
+	margin-bottom: 16px;
+	content: '';
+	display: block;
+	width: 100px;
+	border-bottom: 8px solid;
+	border-color: #295B88;
+}
 
-	.n-messaging-banner__content p {
-		padding-right: 40px;
-	}
+.n-messaging-banner__content p {
+	padding-right: 40px;
+}
 
-	.n-messaging-banner--compact .n-messaging-banner__button {
-		@include oButtonsTheme($theme: (background: (#3A70AF), accent: 'white', colorizer: 'primary'));
-	}
+.n-messaging-banner--compact .n-messaging-banner__button {
+	@include oButtonsTheme($theme: (background: (#3A70AF), accent: 'white', colorizer: 'primary'));
+}
 
-	.n-messaging-banner--compact .n-messaging-banner__button {
-		color: black;
-	}
+.n-messaging-banner--compact .n-messaging-banner__button {
+	color: black;
 }

--- a/templates/partials/bottom/brexit.html
+++ b/templates/partials/bottom/brexit.html
@@ -1,4 +1,4 @@
-<div class="n-messaging-banner variant-{{@nMessagingPresenter.data.variant}}">
+<div class="n-messaging-banner n-messaging-banner--brexit">
 	{{#> n-messaging-client/templates/components/n-messaging-banner
 		small=true
 		themeProduct=true

--- a/templates/partials/bottom/tech-scroll-asia.html
+++ b/templates/partials/bottom/tech-scroll-asia.html
@@ -1,4 +1,4 @@
-<div class="n-messaging-banner variant-{{@nMessagingPresenter.data.variant}}">
+<div class="n-messaging-banner n-messaging-banner--tech-scroll-asia">
 	{{#> n-messaging-client/templates/components/n-messaging-banner
 		themeCompact=true
 		renderOpen=true


### PR DESCRIPTION
It appears that with the new version of n-gage the build is failing due to _verify_stylelint selector-class-pattern

![failed-build](https://user-images.githubusercontent.com/19288962/56188390-4d608500-601d-11e9-817b-05fe73da54fa.png)

So I have made some changes to prevent that. Please check to see if the banners are correct

Brexit:

![Screenshot 2019-04-16 at 07 55 41](https://user-images.githubusercontent.com/19288962/56188437-6701cc80-601d-11e9-9bb5-b96c41fd7a0f.png)


Tech Scoll Asia:

![Screenshot 2019-04-16 at 07 56 01](https://user-images.githubusercontent.com/19288962/56188444-6e28da80-601d-11e9-9c02-68561d875b25.png)


 🐿 v2.12.3