### PR TITLE
Revert "Update offer ID on marketing pop prompt"

### DIFF
--- a/manifest.js
+++ b/manifest.js
@@ -24,7 +24,7 @@ module.exports = {
 	marketingPopupPrompt: {
 		path: 'bottom/lazy',
 		lazy: true,
-		guruQueryString: 'offerId=1dbc248e-b98d-b703-bc25-a05cc5670804'
+		guruQueryString: 'offerId=c1773439-53dc-df3d-9acc-20ce2ecde318'
 	},
 	paymentFailure: {
 		path: 'top/payment-failure'

--- a/secret-squirrel.js
+++ b/secret-squirrel.js
@@ -9,7 +9,7 @@ module.exports = {
 			'45e2193a-f479-11e7-8c80-69ca88a9e8d1', // README.md:186
 			'4312a4ca-aeac-11e8-99ca-68cf89602132', // demos/templates/layouts/custom-vanilla.html:14
 			'97212eb0-abb9-11e8-8253-48106866cd8a', // demos/templates/layouts/custom-vanilla.html:29
-			'1dbc248e-b98d-b703-bc25-a05cc5670804', // manifest.js:27
+			'c1773439-53dc-df3d-9acc-20ce2ecde318', // manifest.js:27
 			'a8785152-8c22-33e8-5af8-2dfeeed3bbae', // templates/partials/bottom/brexit.html:13
 			'5f60b8b4-cbf0-18d7-df41-9caa1171e8c1' // templates/partials/top/anon-subscribe-now.html:5|18
 		]


### PR DESCRIPTION
Reverts Financial-Times/n-messaging-client#142 for this ticket: https://trello.com/c/bohGY4xk/1095-05-marketing-popup-prompt-lionel-slider-link-update