### PR TITLE
Update docs to include info about linting

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,9 @@ if ( window.FT.flags.messageSlotBottom || window.FT.flags.messageSlotTop ) {
 
 - `make install`
 - `make demo` (will build and run demo)
--  visit http://local.ft.com:5005 (make sure you are on `ft.com` so that toggler cookies are used).
+-  visit http://local.ft.com:5005 (make sure you are on `ft.com` so that toggler cookies are used)
+-  before opening a PR, please run `make verify` to check things like linting
+	-  in order to see and fix linting errors, please make sure you have Editor Config and ES Lint plugins installed on your editor of choice
 
 ## Configuring Messages
 


### PR DESCRIPTION
This is to avoid the issues that I had along with other devs from my team when trying to commit to the repo. While consumer products devs may all have ES Lint and Editor Config, not every team does, so clarifying that these are needed to be able to see errors when contributing is very helpful.

Additional changes have been made to the n-gage repo to make seeing and fixing linting errors easier.