### PR TITLE
Remove border bottom style from the download links

### DIFF
--- a/templates/partials/bottom/app-promo-mobile.html
+++ b/templates/partials/bottom/app-promo-mobile.html
@@ -20,10 +20,10 @@
 		<!-- Button and link -->
 		<div class="n-messaging-banner__actions">
 			<div class="n-messaging-banner__action">
-				<a href="https://itunes.apple.com/app/apple-store/id1200842933?mt=8" class="n-messaging-banner__link" data-n-messaging-banner-action="" data-trackable="onsite-message-link-iOS" target="_blank" role="link"><img src="https://www.ft.com/__assets/creatives/tour/apps/ios-download.svg" alt="Download from the iOS App store" height="35"></a>
+				<a href="https://itunes.apple.com/app/apple-store/id1200842933?mt=8" data-n-messaging-banner-action="" data-trackable="onsite-message-link-iOS" target="_blank" role="link"><img src="https://www.ft.com/__assets/creatives/tour/apps/ios-download.svg" alt="Download from the iOS App store" height="35"></a>
 			</div>
 			<div class="n-messaging-banner__action">
-				<a href=" https://play.google.com/store/apps/details?id=com.ft.news&referrer=utm_source%3Dhelp.ft.com" class="n-messaging-banner__link" data-n-messaging-banner-action="" data-trackable="onsite-message-link-googlePlay" target="_blank" role="link"><img src="https://www.ft.com/__origami/service/image/v2/images/raw/https%253A%252F%252Fwww.ft.com%252F__assets%252Fcreatives%252Ftour%252Fapps%252Fgoogle-play-badge-3x.png?source=ip-envoy" height="35" alt="Download on Google Play"></a>
+				<a href=" https://play.google.com/store/apps/details?id=com.ft.news&referrer=utm_source%3Dhelp.ft.com" data-n-messaging-banner-action="" data-trackable="onsite-message-link-googlePlay" target="_blank" role="link"><img src="https://www.ft.com/__origami/service/image/v2/images/raw/https%253A%252F%252Fwww.ft.com%252F__assets%252Fcreatives%252Ftour%252Fapps%252Fgoogle-play-badge-3x.png?source=ip-envoy" height="35" alt="Download on Google Play"></a>
 			</div>
 		</div>
 

--- a/templates/partials/bottom/app-promo-mobile.html
+++ b/templates/partials/bottom/app-promo-mobile.html
@@ -20,10 +20,10 @@
 		<!-- Button and link -->
 		<div class="n-messaging-banner__actions">
 			<div class="n-messaging-banner__action">
-				<a href="https://itunes.apple.com/app/apple-store/id1200842933?mt=8" class=“n-messaging-banner__link” data-n-messaging-banner-action=“” data-trackable=“onsite-message-link-iOS” style="border: 0;" target="_blank" role="link"><img src="https://www.ft.com/__assets/creatives/tour/apps/ios-download.svg" alt="Download from the iOS App store" height="35"></a>
+				<a href="https://itunes.apple.com/app/apple-store/id1200842933?mt=8" class="n-messaging-banner__link" data-n-messaging-banner-action="" data-trackable="onsite-message-link-iOS" target="_blank" role="link"><img src="https://www.ft.com/__assets/creatives/tour/apps/ios-download.svg" alt="Download from the iOS App store" height="35"></a>
 			</div>
 			<div class="n-messaging-banner__action">
-				<a href=" https://play.google.com/store/apps/details?id=com.ft.news&referrer=utm_source%3Dhelp.ft.com" class=“n-messaging-banner__link” data-n-messaging-banner-action=“” style="border: 0;" data-trackable=“onsite-message-link-googlePlay” target="_blank" role="link"><img src="https://www.ft.com/__origami/service/image/v2/images/raw/https%253A%252F%252Fwww.ft.com%252F__assets%252Fcreatives%252Ftour%252Fapps%252Fgoogle-play-badge-3x.png?source=ip-envoy" height="35" alt="Download on Google Play"></a>
+				<a href=" https://play.google.com/store/apps/details?id=com.ft.news&referrer=utm_source%3Dhelp.ft.com" class="n-messaging-banner__link" data-n-messaging-banner-action="" data-trackable="onsite-message-link-googlePlay" target="_blank" role="link"><img src="https://www.ft.com/__origami/service/image/v2/images/raw/https%253A%252F%252Fwww.ft.com%252F__assets%252Fcreatives%252Ftour%252Fapps%252Fgoogle-play-badge-3x.png?source=ip-envoy" height="35" alt="Download on Google Play"></a>
 			</div>
 		</div>
 

--- a/templates/partials/bottom/app-promo-mobile.html
+++ b/templates/partials/bottom/app-promo-mobile.html
@@ -20,10 +20,10 @@
 		<!-- Button and link -->
 		<div class="n-messaging-banner__actions">
 			<div class="n-messaging-banner__action">
-				<a href="https://itunes.apple.com/app/apple-store/id1200842933?mt=8" class=“n-messaging-banner__link” data-n-messaging-banner-action=“” data-trackable=“onsite-message-link-iOS” target="_blank" role="link"><img src="https://www.ft.com/__assets/creatives/tour/apps/ios-download.svg" alt="Download from the iOS App store" height="35"></a>
+				<a href="https://itunes.apple.com/app/apple-store/id1200842933?mt=8" class=“n-messaging-banner__link” data-n-messaging-banner-action=“” data-trackable=“onsite-message-link-iOS” style="border: 0;" target="_blank" role="link"><img src="https://www.ft.com/__assets/creatives/tour/apps/ios-download.svg" alt="Download from the iOS App store" height="35"></a>
 			</div>
 			<div class="n-messaging-banner__action">
-				<a href=" https://play.google.com/store/apps/details?id=com.ft.news&referrer=utm_source%3Dhelp.ft.com" class=“n-messaging-banner__link” data-n-messaging-banner-action=“” data-trackable=“onsite-message-link-googlePlay” target="_blank" role="link"><img src="https://www.ft.com/__origami/service/image/v2/images/raw/https%253A%252F%252Fwww.ft.com%252F__assets%252Fcreatives%252Ftour%252Fapps%252Fgoogle-play-badge-3x.png?source=ip-envoy" height="35" alt="Download on Google Play"></a>
+				<a href=" https://play.google.com/store/apps/details?id=com.ft.news&referrer=utm_source%3Dhelp.ft.com" class=“n-messaging-banner__link” data-n-messaging-banner-action=“” style="border: 0;" data-trackable=“onsite-message-link-googlePlay” target="_blank" role="link"><img src="https://www.ft.com/__origami/service/image/v2/images/raw/https%253A%252F%252Fwww.ft.com%252F__assets%252Fcreatives%252Ftour%252Fapps%252Fgoogle-play-badge-3x.png?source=ip-envoy" height="35" alt="Download on Google Play"></a>
 			</div>
 		</div>
 


### PR DESCRIPTION
 🐿 v2.12.3
- Onsite message, ID `appPromoMobile` downloads links , `border bottom` style updated.