### PR TITLE
Tracking code added to the Download links, message ID , appPromoMobile.

### DIFF
--- a/templates/partials/bottom/app-promo-mobile.html
+++ b/templates/partials/bottom/app-promo-mobile.html
@@ -20,10 +20,10 @@
 		<!-- Button and link -->
 		<div class="n-messaging-banner__actions">
 			<div class="n-messaging-banner__action">
-				<a href="https://itunes.apple.com/app/apple-store/id1200842933?mt=8" data-n-messaging-banner-action="" data-trackable="onsite-message-link-iOS" target="_blank" role="link"><img src="https://www.ft.com/__assets/creatives/tour/apps/ios-download.svg" alt="Download from the iOS App store" height="35"></a>
+				<a href="https://itunes.apple.com/app/apple-store/id1200842933?pt=246269&ct=onsite-messaging&mt=8" target="_blank" role="link"><img src="https://www.ft.com/__assets/creatives/tour/apps/ios-download.svg" alt="Download from the iOS App store" height="35"></a>
 			</div>
 			<div class="n-messaging-banner__action">
-				<a href=" https://play.google.com/store/apps/details?id=com.ft.news&referrer=utm_source%3Dhelp.ft.com" data-n-messaging-banner-action="" data-trackable="onsite-message-link-googlePlay" target="_blank" role="link"><img src="https://www.ft.com/__origami/service/image/v2/images/raw/https%253A%252F%252Fwww.ft.com%252F__assets%252Fcreatives%252Ftour%252Fapps%252Fgoogle-play-badge-3x.png?source=ip-envoy" height="35" alt="Download on Google Play"></a>
+				<a href="https://play.google.com/store/apps/details?id=com.ft.news&referrer=utm_source%3Donsite-messaging%26utm_campaign%3DOnsite%2520Messaging" target="_blank" role="link"><img src="https://www.ft.com/__origami/service/image/v2/images/raw/https%253A%252F%252Fwww.ft.com%252F__assets%252Fcreatives%252Ftour%252Fapps%252Fgoogle-play-badge-3x.png?source=ip-envoy" height="35" alt="Download on Google Play"></a>
 			</div>
 		</div>
 

--- a/templates/partials/bottom/app-promo-mobile.html
+++ b/templates/partials/bottom/app-promo-mobile.html
@@ -20,10 +20,10 @@
 		<!-- Button and link -->
 		<div class="n-messaging-banner__actions">
 			<div class="n-messaging-banner__action">
-				<a href="https://itunes.apple.com/app/apple-store/id1200842933?pt=246269&ct=onsite-messaging&mt=8" target="_blank" role="link"><img src="https://www.ft.com/__assets/creatives/tour/apps/ios-download.svg" alt="Download from the iOS App store" height="35"></a>
+				<a href="https://itunes.apple.com/app/apple-store/id1200842933?pt=246269&ct=onsite-app-promotion&mt=8" target="_blank" role="link"><img src="https://www.ft.com/__assets/creatives/tour/apps/ios-download.svg" alt="Download from the iOS App store" height="35"></a>
 			</div>
 			<div class="n-messaging-banner__action">
-				<a href="https://play.google.com/store/apps/details?id=com.ft.news&referrer=utm_source%3Donsite-messaging%26utm_campaign%3DOnsite%2520Messaging" target="_blank" role="link"><img src="https://www.ft.com/__origami/service/image/v2/images/raw/https%253A%252F%252Fwww.ft.com%252F__assets%252Fcreatives%252Ftour%252Fapps%252Fgoogle-play-badge-3x.png?source=ip-envoy" height="35" alt="Download on Google Play"></a>
+				<a href="https://play.google.com/store/apps/details?id=com.ft.news&referrer=utm_source%3Donsite-app-promotion%26utm_campaign%3DOnsite%2520Messaging" target="_blank" role="link"><img src="https://www.ft.com/__origami/service/image/v2/images/raw/https%253A%252F%252Fwww.ft.com%252F__assets%252Fcreatives%252Ftour%252Fapps%252Fgoogle-play-badge-3x.png?source=ip-envoy" height="35" alt="Download on Google Play"></a>
 			</div>
 		</div>
 


### PR DESCRIPTION
 🐿 v2.12.3
- Tracking code is added to the Download link for both `google play` and `Apple store`
- Google play download link corrected.