### PR TITLE
Upgrade o-loading to a newer version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -39,7 +39,7 @@
     "o-typography": "^5.7.3",
     "n-alert-banner": "^1.0.0",
     "o-overlay": "^2.4.3",
-    "o-loading": "^2.2.2",
+    "o-loading": "^3.1.2",
     "n-swg": "^0.15.0"
   },
   "devDependencies": {

--- a/src/components/bottom/team-trial/main.js
+++ b/src/components/bottom/team-trial/main.js
@@ -4,7 +4,7 @@ const loaderClass = 'o-overlay--n-overlay-loader';
 const iframeClass = 'o-overlay--n-overlay-iframe';
 const generateHtml = (src) => `
 <article class="${loaderClass}">
-	<div class="${loaderClass}-indicator"></div>
+	<div class="${loaderClass}-indicator o-loading o-loading--dark o-loading--large"></div>
 </article>
 <iframe class="${iframeClass}" src="${src}"></iframe>`;
 

--- a/src/components/bottom/team-trial/main.scss
+++ b/src/components/bottom/team-trial/main.scss
@@ -50,12 +50,13 @@
 				position: relative;
 				top: 50%;
 				left: 50%;
-
-				@include oLoadingColor('dark');
-				@include oLoadingSize('large');
-				@include oLoading;
 			}
 		}
+
+		@include oLoading($opts: (
+			'themes': ('dark'),
+			'sizes': ('large')
+		));
 
 		.o-overlay__heading {
 			background-color: oColorsGetPaletteColor('wheat');


### PR DESCRIPTION
Many components require o-loading and to allow us to upgrade them
o-loading has to be on v3.

 🐿 v2.12.3