### PR TITLE
Adds data attrs to enable tracking on act buttons

### DIFF
--- a/templates/partials/bottom/b2b-trial-mobile.html
+++ b/templates/partials/bottom/b2b-trial-mobile.html
@@ -19,10 +19,10 @@
 		<!-- Button and link -->
 		<div class="n-messaging-banner__actions">
 			<div class="n-messaging-banner__action">
-				<a href="https://itunes.apple.com/app/apple-store/id1200842933?mt=8" target="_blank" role="link"><img src="https://www.ft.com/__assets/creatives/tour/apps/ios-download.svg" alt="Download from the iOS App store" height="35"></a>
+				<a href="https://itunes.apple.com/app/apple-store/id1200842933?mt=8" target="_blank" data-n-messaging-banner-action="" data-n-messaging-banner-action-type="ios" role="link"><img src="https://www.ft.com/__assets/creatives/tour/apps/ios-download.svg" alt="Download from the iOS App store" height="35"></a>
 			</div>
 			<div class="n-messaging-banner__action">
-				<a href=" https://play.google.com/store/apps/details?id=com.ft.news&referrer=utm_source%3Dhelp.ft.com" target="_blank" role="link"><img src="https://www.ft.com/__origami/service/image/v2/images/raw/https%253A%252F%252Fwww.ft.com%252F__assets%252Fcreatives%252Ftour%252Fapps%252Fgoogle-play-badge-3x.png?source=ip-envoy" height="35" alt="Download on Google Play"></a>
+				<a href=" https://play.google.com/store/apps/details?id=com.ft.news&referrer=utm_source%3Dhelp.ft.com" target="_blank" data-n-messaging-banner-action="" data-n-messaging-banner-action-type="android" role="link"><img src="https://www.ft.com/__origami/service/image/v2/images/raw/https%253A%252F%252Fwww.ft.com%252F__assets%252Fcreatives%252Ftour%252Fapps%252Fgoogle-play-badge-3x.png?source=ip-envoy" height="35" alt="Download on Google Play"></a>
 			</div>
 		</div>
 


### PR DESCRIPTION
By default anchor tags within `n-messaging-banner__action` don't include
tracking events. Adding these data attributes enables `n-messaging:act`
events for the new app promoting banner for the b2b trial onboarding journey.

 🐿 v2.12.3