### PR TITLE
NBE auto subscription message alert banner

### DIFF
--- a/manifest.js
+++ b/manifest.js
@@ -111,5 +111,8 @@ module.exports = {
 	myFtFeedpage: {
 		path: 'top/my-ft-feedpage',
 		tooltip: true
-	}
+	},
+	nbeAutoSub: {
+		path: 'top/nbe-auto-sub'
+	},
 };

--- a/templates/partials/top/nbe-auto-sub.html
+++ b/templates/partials/top/nbe-auto-sub.html
@@ -1,0 +1,9 @@
+{{> n-messaging-client/templates/components/n-alert-banner
+	theme='neutral'
+	contentTitle=''
+	contentDetail='To get you started with the FT, we’ve signed you up to some newsletters we think you’ll enjoy'
+	buttonLabel='Unsubscribe'
+	buttonUrl='https://enterprise.ft.com/en-gb/engagement/email-opt-in-unsubscribe/'
+	closeButton=false
+	renderOpen=true
+}}

--- a/templates/partials/top/nbe-auto-sub.html
+++ b/templates/partials/top/nbe-auto-sub.html
@@ -1,9 +1,8 @@
 {{> n-messaging-client/templates/components/n-alert-banner
 	theme='neutral'
-	contentTitle=''
-	contentDetail='To get you started with the FT, we’ve signed you up to some newsletters we think you’ll enjoy'
+	contentDetail='To get you started with the FT, we’ve signed you up to some newsletters we think you’ll enjoy.'
 	buttonLabel='Unsubscribe'
 	buttonUrl='https://enterprise.ft.com/en-gb/engagement/email-opt-in-unsubscribe/'
-	closeButton=false
+	closeButton=true
 	renderOpen=true
 }}


### PR DESCRIPTION
This is a new messaging component for our Envoy journey - NBE auto subscription - which automatically signs up B2B triallists to 3 newsletters, unless they opt out by acting on this alert banner.

It's fairly simple, just the neutral Origami alert banner in the top slot, so I think this is everything: create partial and add it to the manifest.