### PR TITLE
Add new OSM.  Link to Daily Digest subscribe page

### DIFF
--- a/manifest.js
+++ b/manifest.js
@@ -109,14 +109,13 @@ module.exports = {
 		tooltip: true
 	},
 	myFtFeedpage: {
-	path: 'top/my-ft-feedpage',
-	tooltip: true
+		path: 'top/my-ft-feedpage',
+		tooltip: true
 	},
 	nbeAutoSub: {
 		path: 'top/nbe-auto-sub'
 	},
 	dailyDigest: {
-		path: 'bottom/lazy',
-		lazy: true
+		path: 'bottom/daily-digest'
 	},
 };

--- a/manifest.js
+++ b/manifest.js
@@ -109,10 +109,14 @@ module.exports = {
 		tooltip: true
 	},
 	myFtFeedpage: {
-		path: 'top/my-ft-feedpage',
-		tooltip: true
+	path: 'top/my-ft-feedpage',
+	tooltip: true
 	},
 	nbeAutoSub: {
 		path: 'top/nbe-auto-sub'
+	},
+	dailyDigest: {
+		path: 'bottom/lazy',
+		lazy: true
 	},
 };

--- a/templates/partials/bottom/daily-digest.html
+++ b/templates/partials/bottom/daily-digest.html
@@ -1,0 +1,17 @@
+<div class="n-messaging-banner">
+		{{#> n-messaging-client/templates/components/n-messaging-banner
+			renderOpen=true
+		}}
+		<div class="n-messaging-banner__inner" data-o-banner-inner="" data-n-messaging-banner-inner="">
+			<div class="n-messaging-banner__content">
+				<p><strong>Sign up to the myFT daily digest</strong></p>
+				<p>Receive the latest news from topics you follow on myFT straight to your inbox</p>
+			</div>
+			<div class="n-messaging-banner__actions">
+					<div class="n-messaging-banner__action">
+							<a href="https://www.ft.com/myft/alerts/" class="n-messaging-banner__button">Sign up</a>
+					</div>
+			</div>
+		</div>
+		{{/n-messaging-client/templates/components/n-messaging-banner}}
+	</div>


### PR DESCRIPTION
 🐿 v2.12.4
This is to support the new Envoy journey 'Predicted to Disengage - NBA'.  For users that have a change in their rfv such that they cross a certain threshold are predicted to disengage, Envoy will present a series of onsite messages designed to re-engage them.  Invititation to subscribe Daily Digest is one of these.  The other OSMs are already implemented and were used in the similar journey, NBA (test).

Presenting a simply link to the Alerts page is not the ideal UX, but is expedient and allows us to put the journey live soon.

The ideal CTA would have been a button on the OSM to subscribe the user directly to Daily Digest but...
.... this is not currently straightforward to implement because the html would need to incorporate a form rather than a simply link, AND would need to have dynamic content (userId and csrf token populated in the fields).

n-messaging-client / next-messaging-guru / o-banner do not currently allow that.

Screenshot attached.
<img width="814" alt="dailyDigestOSM" src="https://user-images.githubusercontent.com/17046637/62945425-9e6b6480-bdd6-11e9-9702-1154fbe456aa.png">
