### PR TITLE
A11y: Make buttons have role="button"

### DIFF
--- a/templates/components/n-alert-banner.html
+++ b/templates/components/n-alert-banner.html
@@ -19,7 +19,7 @@
 			{{#ifSome buttonUrl linkUrl}}
 				<div class="n-alert-banner__actions n-alert-banner__cell" {{#if customDataTrackableActions}} data-trackable="{{customDataTrackableActions}}"{{/if}}>
 					{{#if buttonUrl}}
-					<a href="{{buttonUrl}}" class="n-alert-banner__actions__primary" data-n-alert-banner-action="{{buttonAction}}" data-trackable="{{#if customDataTrackableButton}}{{customDataTrackableButton}}{{else}}onsite-message-button{{/if}}">{{buttonLabel}}</a>
+					<a href="{{buttonUrl}}" class="n-alert-banner__actions__primary" data-n-alert-banner-action="{{buttonAction}}" data-trackable="{{#if customDataTrackableButton}}{{customDataTrackableButton}}{{else}}onsite-message-button{{/if}}" role="button">{{buttonLabel}}</a>
 					{{/if}}
 					{{#if linkUrl}}
 					<a href="{{linkUrl}}" class="n-alert-banner__actions__secondary" data-n-alert-banner-action="{{linkAction}}" data-trackable="{{#if customDataTrackableLink}}{{customDataTrackableLink}}{{else}}onsite-message-link{{/if}}">{{linkLabel}}</a>


### PR DESCRIPTION
This was confusing for users of voice activation software as it looks like a button but behaved like a link.

[Trello ticket](https://trello.com/c/RvFGcUpz/143-dacelementroleissue1)