### PR TITLE
Remove Beacon monitoring link

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ Presentation: [FOMO - a guide](https://docs.google.com/presentation/d/1QpEVjZYQ3
 ### Monitoring
 
 - [Messaging Grafana Board](http://grafana.ft.com/dashboard/db/next-messaging-guru?orgId=1)
-- [Messaging Beacon Board](https://beacon.ft.com/dashboard/messaging/)
 
 # Usage
 


### PR DESCRIPTION
### Description

Beacon and Keen are no longer used by FT.com:

`We've had to delete it because Keen (the underlying third-party data store) are raising prices dramatically in December 2018.`

This link now redirects to https://customer-products.in.ft.com/wiki/Beacon-and-Keen with the above message so removing it from the README in this PR.
