### PR TITLE
New agenda campaign banner

### DIFF
--- a/main.scss
+++ b/main.scss
@@ -1,5 +1,6 @@
 @import './src/components/bottom/onboarding-app/main';
 @import './src/components/top/anon-subscribe-now/main';
+@import './src/components/top/new-agenda/main';
 @import './src/components/bottom/team-trial/main';
 @import './src/components/bottom/b2b-trial-myft/main';
 @import './src/components/bottom/b2b-trial-mobile/main';

--- a/manifest.js
+++ b/manifest.js
@@ -117,4 +117,7 @@ module.exports = {
 		path: 'bottom/lazy',
 		lazy: true
 	},
+	topPromoSlotNewAgendaCampaign : {
+		path: 'top/new-agenda'
+	}
 };

--- a/src/components/top/new-agenda/main.js
+++ b/src/components/top/new-agenda/main.js
@@ -1,0 +1,17 @@
+module.exports = function customSetup (banner, done) {
+
+	const bannerActions = banner.messageElement.querySelector('.n-alert-banner__actions');
+	const bannerButton = banner.messageElement.querySelector('.n-alert-banner__actions__primary');
+
+	bannerActions.className += ' n-alert-banner__actions--clickarea';
+	bannerActions.addEventListener('click', clickEvent => {
+		// Hit test to see if the click originated on expanded click area
+		if (clickEvent.target !== bannerButton) {
+			clickEvent.stopPropagation();
+			bannerButton.click();
+			return false;
+		}
+	});
+
+	done();
+};

--- a/src/components/top/new-agenda/main.scss
+++ b/src/components/top/new-agenda/main.scss
@@ -1,0 +1,46 @@
+.n-alert-banner--marketing__new-agenda {
+	display: none;
+
+	@include oGridRespondTo('M') {
+		display: block;
+		background-color: oColorsGetPaletteColor('lemon');
+	}
+
+	.n-alert-banner__content {
+		align-items: center;
+		display: flex;
+		height: 56px;
+		justify-content: center;
+		padding: 0 20px;
+	}
+
+	.n-alert-banner__cell {
+		padding: 0 15px;
+	}
+
+	.n-alert-banner__content-main {
+		@include oTypographyDisplay($scale: 4);
+		text-transform: uppercase;
+	}
+
+	.n-alert-banner__alternateFontStyle {
+		font-family: Metricweb;
+	}
+
+	.n-alert-banner__actions__primary {
+		@include oMessageButtonBase;
+		@include oButtonsTheme($theme: (background: 'white', accent: 'black', colorizer: 'primary'));
+		margin-right: 0;
+			// This is a hack around the fact that custom buttons do not
+			// support buttons with three colours. TODO: add this to o-buttons
+			// https://github.com/Financial-Times/o-buttons/issues/128
+		&:not([disabled]):hover {
+			background-color: oColorsGetPaletteColor('lemon');
+			color: oColorsGetPaletteColor('black');
+		}
+	}
+
+	.n-alert-banner__actions--clickarea {
+		cursor: pointer;
+	}
+}

--- a/src/components/top/new-agenda/main.scss
+++ b/src/components/top/new-agenda/main.scss
@@ -23,7 +23,7 @@
 		text-transform: uppercase;
 	}
 
-	.n-alert-banner__alternateFontStyle {
+	.n-alert-banner__alternate-font-style {
 		font-family: Metricweb;
 	}
 

--- a/templates/components/n-alert-banner.html
+++ b/templates/components/n-alert-banner.html
@@ -4,7 +4,7 @@
 			{{#ifSome contentTitle contentDetail}}
 				<p class="n-alert-banner__content-main n-alert-banner__cell">
 					{{#if contentTitle}}
-						<span class="n-alert-banner__content-highlight">{{contentTitle}}</span>
+						<span class="n-alert-banner__content-highlight">{{{contentTitle}}}</span>
 					{{/if}}
 					{{#if contentDetail}}
 						<span class="n-alert-banner__content-detail">{{{contentDetail}}}</span>

--- a/templates/partials/top/new-agenda.html
+++ b/templates/partials/top/new-agenda.html
@@ -1,6 +1,6 @@
 {{> n-messaging-client/templates/components/n-alert-banner
 	theme='marketing__new-agenda'
-	contentTitle='<span class="n-alert-banner__alternateFontStyle">Make</span> sense <span class="n-alert-banner__alternateFontStyle">of a disrupted </span>world'
+	contentTitle='<span class="n-alert-banner__alternate-font-style">Make</span> sense <span class="n-alert-banner__alternate-font-style">of a disrupted </span>world'
 	buttonUrl='https://www.ft.com/newagenda'
 	buttonLabel='Explore the new agenda'
 	closeButton=false

--- a/templates/partials/top/new-agenda.html
+++ b/templates/partials/top/new-agenda.html
@@ -1,6 +1,6 @@
 {{> n-messaging-client/templates/components/n-alert-banner
 	theme='marketing__new-agenda'
-	contentTitle='<span class="alternateFontStyle">Make</span> sense <span class="alternateFontStyle">of a disrupted </span>world'
+	contentTitle='<span class="n-alert-banner__alternateFontStyle">Make</span> sense <span class="n-alert-banner__alternateFontStyle">of a disrupted </span>world'
 	buttonUrl='https://www.ft.com/newagenda'
 	buttonLabel='Explore the new agenda'
 	closeButton=false

--- a/templates/partials/top/new-agenda.html
+++ b/templates/partials/top/new-agenda.html
@@ -1,0 +1,7 @@
+{{> n-messaging-client/templates/components/n-alert-banner
+	theme='marketing__new-agenda'
+	contentTitle='<span class="alternateFontStyle">Make</span> sense <span class="alternateFontStyle">of a disrupted </span>world'
+	buttonUrl='https://www.ft.com/newagenda'
+	buttonLabel='Explore the new agenda'
+	closeButton=false
+}}


### PR DESCRIPTION
### Description
Based on the current anonymous subscribe now banner, this is a new variant for the new agenda campaign release - https://trello.com/c/JcC0beJB/1462-1-new-agenda-campaign-release-plan. 

Normal State:
![newAgendaBanner](https://user-images.githubusercontent.com/35195024/64444597-69e48300-d0cc-11e9-82a4-5b39c98653b4.png)

Hover State:
![New Agenda Hover State Banner](https://user-images.githubusercontent.com/35195024/64444590-63eea200-d0cc-11e9-8178-48a700eb8157.png)

Notes:
* Very interested in feedback on how I've implemented the mixed font for the message. (New to handlebars so not sure what a best practise solution would be.)
* Discussed the hover state for the 'button' (it's a link) with Lucinda and agreed for it to be `lemon` and `black`.
* Still to do - media query or handling of smaller screen size. (I'm sorry!! I didn't manage to get this bit done so adding as a separate DOD to the ticket). 
* The 'button' has some javascript to extend the click area as per the current anonymous subscribe banner.
* As discussed with Umberto and Alex, have not yet added the variant to the `messageSlotTop` flag, leaving this to be done for the go-live.

[Trello Card](https://trello.com/c/sXV85Faf/1481-1-implement-campaign-banner)

## Tests:
Additional url now tested automatically by `pa11y` and passing. 