### PR TITLE
Add new agenda paywall freeze banner

### DIFF
--- a/manifest.js
+++ b/manifest.js
@@ -117,7 +117,10 @@ module.exports = {
 		path: 'bottom/lazy',
 		lazy: true
 	},
-	topPromoSlotNewAgendaCampaign : {
+	tnaCampaignBanner : {
 		path: 'top/new-agenda'
+	},
+	tnaPaywallFreezeBanner : {
+		path: 'top/new-agenda-paywall-freeze'
 	}
 };

--- a/src/components/top/new-agenda/main.scss
+++ b/src/components/top/new-agenda/main.scss
@@ -51,4 +51,18 @@
 	.n-alert-banner__actions--clickarea {
 		cursor: pointer;
 	}
+
+	&--paywall-freeze {
+		text-align: center;
+
+		.n-alert-banner__content {
+			height: 94px;
+		}
+
+		.n-alert-banner__content-detail {
+			@include oTypographySize($scale: 2);
+			display: block;
+			font-weight: 600;
+		}
+	}
 }

--- a/templates/partials/top/new-agenda-paywall-freeze.html
+++ b/templates/partials/top/new-agenda-paywall-freeze.html
@@ -1,0 +1,7 @@
+{{> n-messaging-client/templates/components/n-alert-banner
+	theme='marketing__new-agenda'
+	customClass='n-alert-banner--marketing__new-agenda--paywall-freeze'
+	contentTitle='Explore the <em>new agenda</em>'
+	contentDetail='Read FT.com for free now'
+	closeButton=false
+}}


### PR DESCRIPTION
🐿 v2.12.4

## Description

Paywall Freeze Banner that will get displayed for 1 day during the New Agenda campaign.

Also renamed the existing campaign banner to match tracking naming conventions.

## Screenshots

<img src="https://user-images.githubusercontent.com/708296/64792875-034ee180-d572-11e9-9307-da1ca0124f48.png">
