### PR TITLE
fixes myft disengaged tooltip spacing when followers > 0

### DIFF
--- a/src/components/top/myft-disengaged-tooltip/main.js
+++ b/src/components/top/myft-disengaged-tooltip/main.js
@@ -35,10 +35,10 @@ function showHeaderTooltip (banner, followedConcepts = []) {
 		.sort((a, b) => b.lastPublished - a.lastPublished)
 		.map(({name}) => `<span style="white-space: nowrap">${name}</span>`)
 		.slice(0, 3);
-	let content = 'Read the latest';
+	let content = 'Read the latest ';
 
 	if (concepts.length === 3) {
-		content += ` ${concepts.shift()}, `;
+		content += `${concepts.shift()}, `;
 	}
 
 	content += concepts.join(' and ');


### PR DESCRIPTION
add missing space
instead of `read the latestbing, bang and bong stories` display `read the latest bing, bang and bong stories`