### PR TITLE
Hide ABB licence message for the moment

### DIFF
--- a/templates/partials/bottom/abb-licence.html
+++ b/templates/partials/bottom/abb-licence.html
@@ -1,4 +1,4 @@
-<div class="n-messaging-banner n-messaging-banner--secret-content">
+<div class="n-messaging-banner n-messaging-banner--secret-content" style="display: none">
 	{{#> n-messaging-client/templates/components/n-messaging-banner
 		themeCompact=true
 		renderOpen=true


### PR DESCRIPTION
🐿 v2.12.4

While we're testing to make sure this doesn't display to everyone again, forcibly hide the message so it's there in the markup and we can verify it's working as intended.