### PR TITLE
Revert "Hide ABB licence message for the moment"

### DIFF
--- a/templates/partials/bottom/abb-licence.html
+++ b/templates/partials/bottom/abb-licence.html
@@ -1,4 +1,4 @@
-<div class="n-messaging-banner n-messaging-banner--secret-content" style="display: none">
+<div class="n-messaging-banner n-messaging-banner--secret-content">
 	{{#> n-messaging-client/templates/components/n-messaging-banner
 		themeCompact=true
 		renderOpen=true


### PR DESCRIPTION
Reverts Financial-Times/n-messaging-client#186

Tested this and it appears to be working as expected. Re-showing the message.