### PR TITLE
Add BCG message

### DIFF
--- a/manifest.js
+++ b/manifest.js
@@ -81,8 +81,8 @@ module.exports = {
 		path: 'bottom/lazy',
 		lazy: true
 	},
-	abbLicence: {
-		path: 'bottom/abb-licence'
+	bcgLicence: {
+		path: 'bottom/bcg-licence'
 	},
 	appPromoMobile: {
 		path: 'bottom/app-promo-mobile'

--- a/templates/partials/bottom/bcg-licence.html
+++ b/templates/partials/bottom/bcg-licence.html
@@ -7,16 +7,16 @@
 	<div class="n-messaging-banner__inner" data-o-banner-inner="" data-n-messaging-banner-inner="">
 		<div class="n-messaging-banner__content">
 			<header class="n-messaging-banner__heading">
-				<h1>ABB Cancellation</h1>
+				<h1>BCG Cancellation</h1>
 			</header>
 			<p>
-				ABB has decided not to renew their enterprise subscription to FT.com for all global staff.
-				From the 1st of October, you will no longer have full access.
+				BCG has decided not to renew their enterprise subscription to FT.com for all global staff.
+				From the 31st of October, you will no longer have full access.
 			</p>
 		</div>
 		<div class="n-messaging-banner__actions">
 			<div class="n-messaging-banner__action">
-				<a href="https://enterprise.ft.com/en-gb/abb-cancellation-notice" class="n-messaging-banner__button">
+				<a href="https://enterprise.ft.com/en-gb/bcg-cancellation-notice/" class="n-messaging-banner__button">
 					Keep my access
 				</a>
 			</div>


### PR DESCRIPTION
🐿 v2.12.4

[Trello card](https://trello.com/c/FbhyMvZD/1594-bespoke-onsite-message-for-boston-consulting-group)

This is mostly a carbon copy of the ABB licence work that was done previously which is no longer needed (hence all the renaming).

Dependent on https://github.com/Financial-Times/next-ammit-api/pull/594

## Screenshot

<img width="506" alt="1571924332" src="https://user-images.githubusercontent.com/708296/67490972-0d352b80-f66c-11e9-8bbe-51eddc9117b9.png">
