### PR TITLE
First pass 🐿 v2.12.5

### DIFF
--- a/manifest.js
+++ b/manifest.js
@@ -99,7 +99,7 @@ module.exports = {
 		lazy: true
 	},
 	ftWeekendPromo: {
-		path: 'bottom/lazy',
+		path: 'bottom/ft-weekend-promo',
 		lazy: true
 	},
 	giftArticles: {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
     "snyk": "^1.168.0"
   },
   "dependencies": {
-    "@financial-times/n-swg": "^1.0.0"
+    "@financial-times/n-swg": "^1.0.0",
+    "js-cookie": "^2.2.0",
+    "lodash": "^3.0.1"
   }
 }

--- a/src/components/bottom/ft-weekend-promo/main.js
+++ b/src/components/bottom/ft-weekend-promo/main.js
@@ -1,0 +1,55 @@
+const cookies = require('js-cookie');
+const _=require('lodash');
+
+const messageId = 'ftWeekendPromo';
+const messageRules = {messageId, maxOccurrences: {click: 1, view: 3}}; //hide the banner after this number of events
+const stateCookieName = 'nMessagingEventCounter';
+
+function updateLocalCounter (messageId, event) {
+	const currentCounts = cookies.get(stateCookieName) ? JSON.parse(cookies.get(stateCookieName)) : {};
+	const currentCount = _.get(currentCounts, `${messageId}.${event}`) || 0;
+	_.set(currentCounts, `${messageId}.${event}`, currentCount + 1);
+	cookies.set(stateCookieName, currentCounts, { domain: 'ft.com' });
+}
+
+function messageEventLimitsBreached (messageRules) {
+	const currentCounts = cookies.get(stateCookieName) ? JSON.parse(cookies.get(stateCookieName)) : {};
+	const messageId = messageRules.messageId;
+
+	return Object.keys(messageRules.maxOccurrences).some( function (eventType) {
+		const eventCount = _.get(currentCounts, `${messageId}.${eventType}`) || 0;
+		return (eventCount >= messageRules.maxOccurrences[eventType]);
+	});
+}
+
+
+module.exports = function customSetup (banner, done) {
+	const bannerElem = banner.bannerElement;
+	const submitBtn = banner.innerElement.querySelector('.n-messaging-banner__button');
+	const articleLinks = Array.from(banner.innerElement.querySelectorAll('.n-messaging-banner__link'));
+
+	function handleClick () {
+		// the user has clicked on one of the message's CTAs. Therefore we need to update th ecookie accordingly.
+		// Because we can't rely on spoor events to be fired/processed quickly enough to prevent the user seeing the message again.
+		updateLocalCounter(messageId,'click');
+	};
+
+	const removeBanner = () => {
+		bannerElem.parentNode.removeChild(bannerElem);
+		document.body.focus();
+	};
+
+	submitBtn.addEventListener('click', handleClick);
+	articleLinks.map( function (link) {
+		link.addEventListener('click', handleClick);
+	} );
+
+	if (messageEventLimitsBreached(messageRules) ){
+		removeBanner();
+		done({ skip: true });
+	} else {
+		updateLocalCounter(messageId,'view'); // todo.  is this the right way to regsiter viewing of this component?
+		done();
+	}
+
+};

--- a/templates/partials/bottom/ft-weekend-promo.html
+++ b/templates/partials/bottom/ft-weekend-promo.html
@@ -1,0 +1,1 @@
+<div data-n-messaging-component=""></div>


### PR DESCRIPTION
Caters for a scenario not encountered before, where the CTA destination of an OSM is another page set up to display the same OSM.  In this case, the Spoor/Envoy pipeline does not react quickly enough to register a user action and therefore dismiss the message before the next page is rendered (and the message already re-displayed).

Storing OSM state and rules in the browser allows us to prevent this poor user experience.

This PR is a first pass to get us going quickly with ftWeekendPromo, and test this in production for a single message.  If successful, the intention is to extract the new functionality to be easily reusable by other messages.

NB.  A subsequent is also ready for view, and if you don't think it's too risky.. we could just go straight to this one instead, which is generic and will work for any message: 
 https://github.com/Financial-Times/n-messaging-client/pull/196/files