### PR TITLE
New message: myFtFeedpageOverview 🐿 v2.12.5

### DIFF
--- a/main.scss
+++ b/main.scss
@@ -9,3 +9,4 @@
 @import './src/components/bottom/app-promo-mobile/main';
 @import './src/components/bottom/newsletter-promo/main';
 @import './src/components/bottom/ft-weekend-promo/main';
+@import './src/components/bottom/my-ft-feedpage-overview/main';

--- a/manifest.js
+++ b/manifest.js
@@ -127,5 +127,9 @@ module.exports = {
 	},
 	tnaPaywallFreezeBanner : {
 		path: 'top/new-agenda-paywall-freeze'
+	},
+	myFtFeedpageOverview : {
+		path: 'bottom/lazy',
+		lazy: true
 	}
 };

--- a/src/components/bottom/my-ft-feedpage-overview/main.scss
+++ b/src/components/bottom/my-ft-feedpage-overview/main.scss
@@ -1,0 +1,45 @@
+.n-messaging-banner--my-ft-feedpage-overview {
+
+	.n-messaging-banner__inner {
+		background-color: white;
+		background-image: url("https://www.ft.com/__origami/service/image/v2/images/raw/https%3A%2F%2Fenvoy-my-ft-feedpage-overview.s3-eu-west-1.amazonaws.com%2FmyFTFeedpageOverview_graphic.png?source=ip-envoy");
+		background-size: contain;
+		background-repeat: no-repeat;
+		background-position-x: right;
+		background-position-y: bottom;
+		background-size: 50%;
+		color: black;
+	}
+
+	.n-messaging-banner__heading:after {
+		margin-top: 8px;
+		margin-bottom: 16px;
+		content: '';
+		display: block;
+		width: 100px;
+		border-bottom: 0;
+	}
+
+	.n-messaging-banner__content p {
+		width: 50%;
+	}
+
+
+	.n-messaging-banner__topicname {
+		color: #E6175C;
+
+	}
+
+	.n-messaging-banner__button {
+		@include oButtonsTheme($theme: (background: ('white'), accent: 'black', colorizer: 'primary'));
+	}
+
+	.n-messaging-banner__button {
+		color: white;
+	}
+
+
+
+
+
+}

--- a/src/components/bottom/my-ft-feedpage-overview/main.scss
+++ b/src/components/bottom/my-ft-feedpage-overview/main.scss
@@ -1,14 +1,17 @@
 .n-messaging-banner--my-ft-feedpage-overview {
 
 	.n-messaging-banner__inner {
-		background-color: white;
-		background-image: url("https://www.ft.com/__origami/service/image/v2/images/raw/https%3A%2F%2Fenvoy-my-ft-feedpage-overview.s3-eu-west-1.amazonaws.com%2FmyFTFeedpageOverview_graphic.png?source=ip-envoy");
-		background-size: contain;
-		background-repeat: no-repeat;
-		background-position-x: right;
-		background-position-y: bottom;
-		background-size: 50%;
 		color: black;
+		background: white;
+
+		@include oGridRespondTo($from: M) {
+			background-image: url("https://www.ft.com/__origami/service/image/v2/images/raw/https%3A%2F%2Fenvoy-my-ft-feedpage-overview.s3-eu-west-1.amazonaws.com%2FmyFTFeedpageOverview_graphic.png?source=ip-envoy");
+			background-size: contain;
+			background-repeat: no-repeat;
+			background-position-x: right;
+			background-position-y: bottom;
+			background-size: 50%;
+		}
 	}
 
 	.n-messaging-banner__heading:after {
@@ -20,23 +23,28 @@
 		border-bottom: 0;
 	}
 
+	/* so the text doesn't overlap when background image is displayed */
 	.n-messaging-banner__content p {
-		width: 50%;
+		@include oGridRespondTo($from: M) {
+			width: 50%;
+		}
 	}
 
 
 	.n-messaging-banner__topicname {
 		color: #E6175C;
-
-	}
-
-	.n-messaging-banner__button {
-		@include oButtonsTheme($theme: (background: ('white'), accent: 'black', colorizer: 'primary'));
 	}
 
 	.n-messaging-banner__button {
 		color: white;
+		background-color: black;
+		&:hover,
+		&:focus {
+			color: black;
+			background-color: white;
+		}
 	}
+
 
 
 


### PR DESCRIPTION
New message for use by Envoy team in a new journey, to test NBA models against each other. 
(see https://docs.google.com/presentation/d/1Cd9pvhmrnYZLhV0v9I9YmYXLno0l_hb7mfNkUk_e2dE/edit#slide=id.g50dea84098_0_0)

This is the ticket for creating the message:  https://trello.com/c/6UZygtZL/609-nba-a-b-test-build-myft-feedpage-on-site-message

Relies on the dynamic content provided by messaging-guru:  https://github.com/Financial-Times/next-messaging-guru/pull/60

Mocked up images here from the design team: 
![image](https://user-images.githubusercontent.com/17046637/69626786-43861200-1041-11ea-811f-5788b8c10dbb.png)
![image](https://user-images.githubusercontent.com/17046637/69626857-687a8500-1041-11ea-91ad-94370dc1de9e.png)

Screenshot of the message rendered by n-messaging-client running locally:
![image](https://user-images.githubusercontent.com/17046637/69627464-898fa580-1042-11ea-9344-ba4557241dca.png)
