### PR TITLE
Senta/app pomo mobile

### DIFF
--- a/src/components/bottom/app-promo-mobile/main.scss
+++ b/src/components/bottom/app-promo-mobile/main.scss
@@ -4,7 +4,6 @@
 		top: 20px;
 		position: absolute;
 	}
-	
 	.n-messaging-banner__content--img {
 		margin-left: 238px;
 	}

--- a/src/components/bottom/app-promo-mobile/main.scss
+++ b/src/components/bottom/app-promo-mobile/main.scss
@@ -1,16 +1,18 @@
 .n-messaging-banner--app-promo-mobile {
 	.app-promo-mobile__device {
-		left: 70px;
+		left: 90px;
 		top: 20px;
 		position: absolute;
 	}
-	.n-messaging-banner__action {
+	
+	.n-messaging-banner__content--img {
+		margin-left: 238px;
+	}
+
+	.n-messaging-banner__actions {
 		a {
 			border-bottom: 0;
 			outline: 0;
 		}
-	}
-	.n-messaging-banner__content p {
-		padding-left: 190px;
 	}
 }


### PR DESCRIPTION
This is to fix the styling issue of appPromoMobile message on the mobile device.

### It was look like this 
<img width="584" alt="Screenshot 2019-12-05 at 15 24 50" src="https://user-images.githubusercontent.com/22526374/70248886-82b80f80-1773-11ea-99e1-ca35bf5b87d0.png">

### Now Looks Like this 

<img width="447" alt="Screenshot 2019-12-05 at 15 25 26" src="https://user-images.githubusercontent.com/22526374/70248894-85b30000-1773-11ea-8716-3eaa5513301c.png">
