### PR TITLE
The onsite message(appPromoMobile) styling issue on mobile device is …

### DIFF
--- a/src/components/bottom/app-promo-mobile/main.scss
+++ b/src/components/bottom/app-promo-mobile/main.scss
@@ -1,16 +1,18 @@
 .n-messaging-client-messaging-banner--app-promo-mobile {
 	.app-promo-mobile__device {
-		left: 70px;
+		left: 90px;
 		top: 20px;
 		position: absolute;
 	}
-	.o-banner__action {
+
+	.o-banner__content--img {
+		margin-left: 238px;
+	}
+
+	.o-banner__actions {
 		a {
 			border-bottom: 0;
 			outline: 0;
 		}
-	}
-	.o-banner__content p {
-		padding-left: 190px;
 	}
 }


### PR DESCRIPTION
…fixed 🐿 v2.12.5
This is to fix the styling issue of appPromoMobile message on the mobile device.

### It was look like this

<img width="584" alt="Old" src="https://user-images.githubusercontent.com/22526374/70341453-db0e1080-184a-11ea-8c79-01759d99073a.png">

### Now look like this
<img width="447" alt="new" src="https://user-images.githubusercontent.com/22526374/70341472-e6613c00-184a-11ea-937c-38479ce75226.png">
