### PR TITLE
fix: explicitly include banner styles

### DIFF
--- a/critical.scss
+++ b/critical.scss
@@ -17,6 +17,8 @@ $o-tooltip-is-silent : false;
 @include oFontsInclude(FinancierDisplayWeb, $weight: bold);
 @include oBanner($class: 'n-messaging-banner', $themes: 'all');
 @include oMessage($class: 'n-alert-banner', $types: 'alert', $status: 'all');
+@include oMessage($class: 'n-alert-banner', $types: 'alert', $status: 'error');
+@include oMessage($class: 'n-alert-banner', $types: 'alert', $status: 'neutral');
 
 // ensure the bottom o-banner displays above other elements on page (e.g. imgs on article page)
 .n-messaging-banner {


### PR DESCRIPTION
Currently, theres a bug on next-article where the payment error message and the NBE banner (both relying on default oMessage styling) aren't receiving the default styles. I have replicated this locally.

Although the documentation (and the code) looks to automatically include all message states if you pass in "all" - on article this does not seem to be the case. This PR explicitly adds in the error and neutral states which outputs the required CSS



