### PR TITLE
Remove alt text for banner images

### DIFF
--- a/templates/components/o-message.html
+++ b/templates/components/o-message.html
@@ -13,7 +13,7 @@
 			{{/ifSome}}
 			{{#if contentImage}}
 			<div class="o-message__image o-message__cell">
-				<img src="{{contentImage}}" alt="{{contentTitle}}">
+				<img src="{{contentImage}}" alt="">
 			</div>
 			{{/if}}
 			{{#ifSome buttonUrl linkUrl}}


### PR DESCRIPTION
Currently if a banner title exists, it is used as the alt text for the banner image. This may cause issues for screen reader users because the image is placed next to the text so the message is announced twice.

Also, the text itself doesn't convey meaningful information about the image.

DAC ticket: https://trello.com/c/i2TjYybE/154-decorative-image-with-alt-issue-id-dacdecorativeimage01