### PR TITLE
Adds .default to the o-banner require statement, resolving ES6/CJM errors

### DIFF
--- a/src/client/bottom-slot.js
+++ b/src/client/bottom-slot.js
@@ -1,4 +1,4 @@
-const oBanner = require('o-banner');
+const oBanner = require('o-banner').default;
 const { generateMessageEvent, listen, messageEventLimitsBreached } = require('./utils');
 
 const BOTTOM_SLOT_CONTENT_SELECTOR = '[data-n-messaging-slot="bottom"] [data-n-messaging-component]';


### PR DESCRIPTION
Adds a missing `.default` to the oBanner require statement in n-messaging-client to resolve an ES6/CJM interoperability error.

`o-banner` is exported as a default so it will need to be imported using this syntax. https://github.com/Financial-Times/o-banner/blob/master/main.js#L11 

In Page Kit apps, this causes a `TypeError: oBanner.getOptionsFromDom is not a function` error to thrown when initialising n-messaging-client (which refers to [this line](https://github.com/Financial-Times/n-messaging-client/blob/master/src/client/bottom-slot.js#L18) in the same file)

n-messaging-client is currently required by next-front-page, next-stream-page and next-article but there are no errors in production for these apps because n-ui contains a hack which lets it resolve the current require statement.