### PR TITLE
Add 25% offer id related to the priceIncreaseTest2020 work 🐿 v2.12.5

### DIFF
--- a/manifest.js
+++ b/manifest.js
@@ -18,7 +18,9 @@ module.exports = {
 	marketingPopupPrompt: {
 		path: 'bottom/lazy',
 		lazy: true,
-		guruQueryString: 'offerId=c1773439-53dc-df3d-9acc-20ce2ecde318'
+		// Temporary 25% off offer. Related to priceIncreaseTest2020 work.
+		guruQueryString: 'offerId=2a6a4586-ace0-6465-aebe-aa1ecc543271'
+		// guruQueryString: 'offerId=c1773439-53dc-df3d-9acc-20ce2ecde318'
 	},
 	tnaMarketingPopupPrompt: {
 		path: 'bottom/new-agenda'

--- a/secret-squirrel.js
+++ b/secret-squirrel.js
@@ -9,12 +9,14 @@ module.exports = {
 			'45e2193a-f479-11e7-8c80-69ca88a9e8d1', // README.md:187
 			'4312a4ca-aeac-11e8-99ca-68cf89602132', // demos/templates/layouts/custom-vanilla.html:14
 			'97212eb0-abb9-11e8-8253-48106866cd8a', // demos/templates/layouts/custom-vanilla.html:29
-			'c1773439-53dc-df3d-9acc-20ce2ecde318', // manifest.js:21
+			'priceIncreaseTest2020', // manifest.js:21
+			'2a6a4586-ace0-6465-aebe-aa1ecc543271', // manifest.js:22
+			'c1773439-53dc-df3d-9acc-20ce2ecde318', // manifest.js:23
 			'ed76f4a7-dcc0-f60d-5f92-0bd9b43f30dd', // templates/partials/bottom/b2b-trial-contact-us.html:21
 			'eb62aef2-4bdc-0f31-a2c5-6532b8e17896', // templates/partials/bottom/content-message.html:15
 			'ae5ae5b5-cf1e-6ecc-d83e-4af44b410722', // templates/partials/bottom/new-agenda.html:16
 			'5f60b8b4-cbf0-18d7-df41-9caa1171e8c1', // templates/partials/top/anon-subscribe-now.html:5|18
-			'58faf1a5-41a3-0485-e2b0-f045491b585a', // templates/partials/top/new-agenda.html:4,
+			'58faf1a5-41a3-0485-e2b0-f045491b585a', // templates/partials/top/new-agenda.html:4
 			'a44c9005-2a9c-fe2a-9140-1311ff87f25f', // templates/partials/top/print-banner-usa.html:4
 			'79c8c0c5-1686-7f28-3aeb-c14688d59749' // templates/partials/top/uk-election.html:4
 		]


### PR DESCRIPTION
Exactly the same as https://github.com/Financial-Times/n-messaging-client/pull/231, but for non-page-kit apps like Front Page, Stream Page, and Articles.