### PR TITLE
Remove unnecessary getters from slot presenter.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ demo-build-watch: link-templates
 	@$(DONE)
 
 demo: demo-build-watch
-	@DEMO_MODE=true nodemon --ext html,css --watch public --watch templates demos/app.js
+	@DEMO_MODE=true nodemon --inspect --ext html,css --watch public --watch templates demos/app.js
 
 run:
 	@DEMO_MODE=true node demos/app

--- a/src/presenters/slot-presenter.js
+++ b/src/presenters/slot-presenter.js
@@ -36,15 +36,9 @@ const SlotPresenter = class SlotPresenter {
 		this._data = _data || {};
 		this.position = dataTypeContract(_data.type) && _data.type;
 		const root = this._data.root || {};
-		this.config = getConfig(this.position, root, parseFlagsObject(root.flags));
-	}
+		this.data = getConfig(this.position, root, parseFlagsObject(root.flags));
 
-	get data () {
-		return this.config;
-	}
-
-	get hasMessage () {
-		return !!(this.config.variant && this.config.path);
+		this.hasMessage = !!(this.data.variant && this.data.path);
 	}
 
 };


### PR DESCRIPTION
For some reason, handlebars was calling the presenter (I was able to get
a breakpoint to catch inside the getters) but wasn't receiving the value
being returned. Eventually came to the realisation that these don't need
to be getters at all as far as we could tell so just setting them as
static properties.

🐿 v2.12.5