### PR TITLE
Monkey patch o-banner import

### DIFF
--- a/src/client/bottom-slot.js
+++ b/src/client/bottom-slot.js
@@ -1,4 +1,6 @@
-const oBanner = require('o-banner').default;
+let oBanner = require('o-banner');
+oBanner = oBanner.default || oBanner;
+
 const { generateMessageEvent, listen, messageEventLimitsBreached } = require('./utils');
 
 const BOTTOM_SLOT_CONTENT_SELECTOR = '[data-n-messaging-slot="bottom"] [data-n-messaging-component]';


### PR DESCRIPTION
This is temporary. As it stands, the require with `default` works in `next-article` and `next-stream-page` but not `next-front-page`. This will make it work everywhere without having to do an overhaul of front-page.

🐿 v2.12.5

And yes... I know:

![](https://user-images.githubusercontent.com/708296/72153212-2749f480-33a5-11ea-8747-59b882c41111.gif)
