### PR TITLE
Merge pull request #239 from Financial-Times/nbeMessageSwingToConservatives

### DIFF
--- a/main.scss
+++ b/main.scss
@@ -10,3 +10,4 @@
 @import './src/components/bottom/my-ft-feedpage-overview/main';
 @import './src/components/bottom/fast-ft/main';
 @import './src/components/bottom/markets-data/main';
+@import './src/components/top/nbe-auto-sub/main';

--- a/src/components/top/nbe-auto-sub/main.scss
+++ b/src/components/top/nbe-auto-sub/main.scss
@@ -4,17 +4,17 @@
 	background-color: oColorsByName('teal-80');
 
 	.o-message__content {
-		padding-bottom: 8px;
+		padding-bottom: oSpacingByName('s2');
 	}
 
 	@include oGridRespondTo('M') {
 		.o-message__content-main {
-				@include oTypographyDisplay($scale: 3);
+			@include oTypographyDisplay($scale: 3);
 		}
 	}
 
 	.o-message__cell {
-		padding: 0 15px;
+		padding: 0 oSpacingByName('s4');
 	}
 
 	.o-message__actions__primary {

--- a/src/components/top/nbe-auto-sub/main.scss
+++ b/src/components/top/nbe-auto-sub/main.scss
@@ -1,0 +1,46 @@
+.n-messaging-client-alert-banner--marketing__nbe-auto-sub {
+
+	display: block;
+	background-color: oColorsByName('teal-80');
+
+	.o-message__content {
+		padding-bottom: 8px;
+	}
+
+	@include oGridRespondTo('M') {
+		.o-message__content-main {
+				@include oTypographyDisplay($scale: 3);
+		}
+	}
+
+	.o-message__cell {
+		padding: 0 15px;
+	}
+
+	.o-message__actions__primary {
+		@include oButtonsContent($opts: (
+			'type': 'primary',
+			'theme': (
+				'color': 'black',
+				'context': 'white'
+			)
+		), $include-base-styles: false);
+		margin-right: 0;
+	}
+
+	.o-message__actions--clickarea {
+		cursor: pointer;
+	}
+
+	&--dark {
+		background-color: oColorsByName('black');
+		color: oColorsByName('white');
+
+		.o-message__actions__primary {
+			@include oButtonsContent($opts: (
+				'type': 'primary',
+				'theme': 'inverse'
+			), $include-base-styles: false);
+		}
+	}
+}

--- a/templates/partials/top/nbe-auto-sub.html
+++ b/templates/partials/top/nbe-auto-sub.html
@@ -1,9 +1,8 @@
 {{> n-messaging-client/templates/components/o-message
-	theme='neutral'
-	contentTitle='Unsubscribe'
-	contentDetail='To get you started with the FT, we’ve signed you up to some newsletters we think you’ll enjoy.'
+	theme='marketing__nbe-auto-sub'
+	contentTitle='To get you started with the FT, we’ve signed you up to some newsletters we think you’ll enjoy'
 	buttonLabel='Unsubscribe'
 	buttonUrl='https://enterprise.ft.com/en-gb/engagement/email-opt-in-unsubscribe/'
-	closeButton=true
+	closeButton=false
 	renderOpen=true
 }}


### PR DESCRIPTION
 So it is more prominent to the user.  And teal!

Current look:
![image](https://user-images.githubusercontent.com/17046637/72616051-fa11bf00-392d-11ea-9ef4-12a68b1b8d9f.png)
![image](https://user-images.githubusercontent.com/17046637/72616062-ff6f0980-392d-11ea-9364-500aaf847e77.png)

New look:
![image](https://user-images.githubusercontent.com/17046637/72616009-e23a3b00-392d-11ea-9237-82702fe7f7a9.png)
![image](https://user-images.githubusercontent.com/17046637/72616022-ebc3a300-392d-11ea-8c17-70effc4d69ff.png)

NB.  It is deliberate to omit the Close button.  This message will only be shown to users who are on a specific Envoy journey (nbeAutoSub-v2). The journey will ensure that once viewed, the message will not be removed until: a) one day has passed OR b) the user clicks the Unsubscribe button.  More info on this journey here: https://docs.google.com/presentation/d/10MeQPXVPP4GQTdgNYWPqmHouIlPrqhJ2nX89Ur-TDyw/edit#slide=id.g50dea84098_0_0