### PR TITLE
Adds ability to track dynamic content in OSMs

### DIFF
--- a/src/client/bottom-slot.js
+++ b/src/client/bottom-slot.js
@@ -13,7 +13,8 @@ const BOTTOM_SLOT_FLAG = 'messageSlotBottom';
 
 module.exports = function ({ config={}, guruResult, customSetup }={}) {
 	let banner;
-	const trackEventAction = config.name && generateMessageEvent({ messageId: config.name, position: config.slot, variant: config.name, flag: BOTTOM_SLOT_FLAG });
+	const variant = (guruResult && guruResult.renderData && guruResult.renderData.dynamicTrackingData) || config.name
+	const trackEventAction = config.name && generateMessageEvent({ messageId: config.name, position: config.slot, variant: variant, flag: BOTTOM_SLOT_FLAG });
 	const declarativeElement = !config.lazy && config.content;
 
 	if (declarativeElement) {
@@ -97,6 +98,7 @@ function imperativeOptions (opts = {}, defaults = {}) {
 		buttonUrl: opts.buttonUrl,
 		linkLabel: opts.linkLabel,
 		linkUrl: opts.linkUrl,
-		appendTo: BOTTOM_SLOT_CONTENT_SELECTOR
+		appendTo: BOTTOM_SLOT_CONTENT_SELECTOR,
+		dynamicTrackingData: opts.dynamicTrackingData
 	};
 }

--- a/src/client/bottom-slot.js
+++ b/src/client/bottom-slot.js
@@ -13,7 +13,7 @@ const BOTTOM_SLOT_FLAG = 'messageSlotBottom';
 
 module.exports = function ({ config={}, guruResult, customSetup }={}) {
 	let banner;
-	const variant = (guruResult && guruResult.renderData && guruResult.renderData.dynamicTrackingData) || config.name
+	const variant = (guruResult && guruResult.renderData && guruResult.renderData.dynamicTrackingData) || config.name;
 	const trackEventAction = config.name && generateMessageEvent({ messageId: config.name, position: config.slot, variant: variant, flag: BOTTOM_SLOT_FLAG });
 	const declarativeElement = !config.lazy && config.content;
 

--- a/src/client/top-slot.js
+++ b/src/client/top-slot.js
@@ -11,7 +11,8 @@ const TOP_SLOT_FLAG = 'messageSlotTop';
 
 module.exports = function ({ config={}, guruResult, customSetup }={}) {
 	let alertBanner;
-	const trackEventAction = config.name && generateMessageEvent({ messageId: config.name, position: config.slot, variant: config.name, flag: TOP_SLOT_FLAG });
+	const variant = (guruResult && guruResult.renderData && guruResult.renderData.dynamicTrackingData) || config.name;
+	const trackEventAction = config.name && generateMessageEvent({ messageId: config.name, position: config.slot, variant: variant, flag: TOP_SLOT_FLAG });
 	const declarativeElement = !config.lazy && config.content;
 	const options = { messageClass: ALERT_BANNER_CLASS, autoOpen: false, close: message.getDataAttributes(declarativeElement).close};
 
@@ -89,6 +90,7 @@ function imperativeOptions (opts, defaults) {
 				url: opts.linkUrl
 			}
 		},
-		close: opts.closeButton
+		close: opts.closeButton,
+		dynamicTrackingData: opts.dynamicTrackingData
 	};
 }


### PR DESCRIPTION
When a view event is fired from n-messaging-client we have no way of knowing the dynamic content that the message contained. This is ok when the messages are static and the contents remains the same but doesn't work for dynamic messages with changing content.

As an example, if we're pushing topic recommendations into a message, these could be different for each user. We need to be able to see which topics were present when a user views the message.

For now, we're making use of the `messaging_variant` field that is already present in the tracking events and used by the analytics team. By default, this field contains the message name -
![image](https://user-images.githubusercontent.com/900140/73473968-8b008580-4385-11ea-887e-bcb2f9259c54.png)

This change allows `messaging_variant` to contain a string that explains the dynamic content contained in the message. e.g
![image](https://user-images.githubusercontent.com/900140/73474253-0c581800-4386-11ea-967e-e2dfdc109a7e.png)


🐿 v2.12.5