### PR TITLE
Update o-banner

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -31,7 +31,7 @@
   ],
   "dependencies": {
     "n-ui-foundations": "^4.0.0-beta.1",
-    "o-banner": "^3.0.0",
+    "o-banner": "^3.2.0",
     "o-share": "^7.0.0",
     "o-tooltip": "^4.0.0",
     "next-myft-client": "^7.7.0",


### PR DESCRIPTION
Making sure that o-banner v3.2.0 is used at a minumum.
This allows custom banners to be more easily created.