### PR TITLE
Bugfix: increases the CSS specificity for o-banner__inner background …

### DIFF
--- a/src/components/bottom/fast-ft/main.scss
+++ b/src/components/bottom/fast-ft/main.scss
@@ -1,16 +1,17 @@
 .n-messaging-client-messaging-banner--fast-ft {
+	.o-banner__outer {
+		.o-banner__inner {
+			color: black;
+			background: white;
 
-	.o-banner__inner {
-		color: black;
-		background: white;
-
-		@include oGridRespondTo($from: M) {
-			background-image: url("https://www.ft.com/__origami/service/image/v2/images/raw/https%3A%2F%2Fenvoy-fast-ft.s3-eu-west-1.amazonaws.com%2FfastFT_promo_message_graphic.png?source=ip-envoy&width=220");
-			background-size: contain;
-			background-repeat: no-repeat;
-			background-position-x: calc(100% + 1px); // a workaround to remove 1px gap on the right/bottom
-			background-position-y: calc(100% + 1px);
-			background-size: 45%;
+			@include oGridRespondTo($from: M) {
+				background-image: url("https://www.ft.com/__origami/service/image/v2/images/raw/https%3A%2F%2Fenvoy-fast-ft.s3-eu-west-1.amazonaws.com%2FfastFT_promo_message_graphic.png?source=ip-envoy&width=220");
+				background-size: contain;
+				background-repeat: no-repeat;
+				background-position-x: calc(100% + 1px); // a workaround to remove 1px gap on the right/bottom
+				background-position-y: calc(100% + 1px);
+				background-size: 45%;
+			}
 		}
 	}
 

--- a/src/components/bottom/ft-weekend-promo/main.scss
+++ b/src/components/bottom/ft-weekend-promo/main.scss
@@ -1,12 +1,14 @@
 .n-messaging-client-messaging-banner--ft-weekend-promo {
-	.o-banner__inner {
-		background-color: #262A33;
-		background-image: url("https://www.ft.com/__origami/service/image/v2/images/raw/https%3A%2F%2Fenvoy-ft-weekend-promo.s3-eu-west-1.amazonaws.com%2Fleaf_motif.png?source=ip-envoy");
-		background-size: contain;
-		background-repeat: no-repeat;
-		background-position-x: right;
-		color: white;
-		border: 5px solid white;
+	.o-banner__outer {
+		.o-banner__inner {
+			background-color: #262A33;
+			background-image: url("https://www.ft.com/__origami/service/image/v2/images/raw/https%3A%2F%2Fenvoy-ft-weekend-promo.s3-eu-west-1.amazonaws.com%2Fleaf_motif.png?source=ip-envoy");
+			background-size: contain;
+			background-repeat: no-repeat;
+			background-position-x: right;
+			color: white;
+			border: 5px solid white;
+		}
 	}
 
 	.o-banner__close {

--- a/src/components/bottom/markets-data/main.scss
+++ b/src/components/bottom/markets-data/main.scss
@@ -1,16 +1,17 @@
 .n-messaging-client-messaging-banner--markets-data {
+	.o-banner__outer {
+		.o-banner__inner {
+			color: black;
+			background: white;
 
-	.o-banner__inner {
-		color: black;
-		background: white;
-
-		@include oGridRespondTo($from: M) {
-			background-image: url("https://www.ft.com/__origami/service/image/v2/images/raw/https%3A%2F%2Fenvoy-markets-data.s3-eu-west-1.amazonaws.com%2Fmarkets_data.png?source=ip-envoy&width=196");
-			background-size: contain;
-			background-repeat: no-repeat;
-			background-position-x: calc(100% + 1px); // a workaround to remove 1px gap on the right/bottom
-			background-position-y: calc(100% + 1px);
-			background-size: 40%;
+			@include oGridRespondTo($from: M) {
+				background-image: url("https://www.ft.com/__origami/service/image/v2/images/raw/https%3A%2F%2Fenvoy-markets-data.s3-eu-west-1.amazonaws.com%2Fmarkets_data.png?source=ip-envoy&width=196");
+				background-size: contain;
+				background-repeat: no-repeat;
+				background-position-x: calc(100% + 1px); // a workaround to remove 1px gap on the right/bottom
+				background-position-y: calc(100% + 1px);
+				background-size: 40%;
+			}
 		}
 	}
 

--- a/src/components/bottom/tech-scroll-asia/main.scss
+++ b/src/components/bottom/tech-scroll-asia/main.scss
@@ -1,11 +1,13 @@
 .n-messaging-client-messaging-banner--tech-scroll-asia {
-	.o-banner__inner {
-		background-color: #003B71;
-		background-image: url("https://www.ft.com/__origami/service/image/v2/images/raw/https%3A%2F%2Fs3-eu-west-1.amazonaws.com%2Fenvoy-tsa%2Ftsabg.png?source=ip-envoy&width=236&height=450");
-		background-size: contain;
-		background-repeat: no-repeat;
-		background-position-x: right;
-		color: white;
+	.o-banner__outer {
+		.o-banner__inner {
+			background-color: #003B71;
+			background-image: url("https://www.ft.com/__origami/service/image/v2/images/raw/https%3A%2F%2Fs3-eu-west-1.amazonaws.com%2Fenvoy-tsa%2Ftsabg.png?source=ip-envoy&width=236&height=450");
+			background-size: contain;
+			background-repeat: no-repeat;
+			background-position-x: right;
+			color: white;
+		}
 	}
 
 	.o-banner__close {


### PR DESCRIPTION
…styles 🐿 v2.12.5

Increases the CSS specificity for the `TechsScrollAsia`, `FtWeekendPromo`, `FastFt` and `MarketsData` overlays. This solves a cascade bug which was causing `o-banner__inner` styles defined in o-banner to overwrite the custom background styles defined in n-messaging-client for the same class. 

The problem only appeared the Article Page so I've tested these changes in the Front Page to make sure they don't have any unintended effects there. 

TechsScrollAsia Before
<img width="551" alt="Screenshot 2020-02-18 at 10 55 45" src="https://user-images.githubusercontent.com/17549437/74730059-6178a280-523d-11ea-85ef-a14698f57fd4.png">

TechsScrollAsia After
<img width="565" alt="Screenshot 2020-02-18 at 10 54 23" src="https://user-images.githubusercontent.com/17549437/74730069-650c2980-523d-11ea-933c-aabce387b243.png">
