### PR TITLE
A new coronavirus newsletter promotion

### DIFF
--- a/client/components/bottom/coronavirus-newsletter-promo/main.scss
+++ b/client/components/bottom/coronavirus-newsletter-promo/main.scss
@@ -1,0 +1,8 @@
+.n-messaging-coronavirus {
+	&__highlight-regular {
+		font-weight: 400;
+	}
+	&__highlight-color {
+		color: oColorsByName('lemon');
+	}
+}

--- a/client/themes.scss
+++ b/client/themes.scss
@@ -10,7 +10,7 @@
 	text-color: oColorsMix('black', 'jade', $percentage: 43)
 ));
 
-@include oBannerAddTheme('pikachu', (
+@include oBannerAddTheme('slate-lemon', (
 	background-color: oColorsByName('slate'),
 	text-color: oColorsByName('white'),
 	button-background-color: oColorsByName('lemon'),

--- a/client/themes.scss
+++ b/client/themes.scss
@@ -9,3 +9,10 @@
 	background-color: oColorsMix('jade', $percentage: 20),
 	text-color: oColorsMix('black', 'jade', $percentage: 43)
 ));
+
+@include oBannerAddTheme('pikachu', (
+	background-color: oColorsByName('slate'),
+	text-color: oColorsByName('white'),
+	button-background-color: oColorsByName('lemon'),
+	heading-rule-color: oColorsByName('lemon'),
+));

--- a/main.scss
+++ b/main.scss
@@ -16,3 +16,4 @@ $system-code: 'n-messaging-client';
 @import './client/components/top/nbe-auto-sub/main';
 @import './client/components/bottom/myft-account-topic-recs/main';
 @import './client/components/bottom/us-election-2020-promo/main';
+@import './client/components/bottom/coronavirus-newsletter-promo/main';

--- a/manifest.js
+++ b/manifest.js
@@ -146,5 +146,8 @@ module.exports = {
 	},
 	usElection2020Promo: {
 		path: 'bottom/us-election-2020-promo'
+	},
+	coronavirusNewsletterPromo: {
+		path: 'bottom/coronavirus-newsletter-promo'
 	}
 };

--- a/server/templates/components/o-banner.html
+++ b/server/templates/components/o-banner.html
@@ -3,7 +3,7 @@
 	{{#if themeMarketing}} o-banner--marketing{{/if}}
 	{{#if themeProduct}} o-banner--product{{/if}}
 	{{#if themeCompact}} o-banner--compact{{/if}}
-	{{#if themePikachu}} o-banner--pikachu{{/if}}
+	{{#if themeSlateLemon}} o-banner--slate-lemon{{/if}}
 	{{#if small}} o-banner--small{{/if}}"
 	data-n-messaging-component=""
 	data-o-banner-banner-class="{{#if bannerClass}}{{bannerClass}}{{else}}o-banner{{/if}}"

--- a/server/templates/components/o-banner.html
+++ b/server/templates/components/o-banner.html
@@ -3,6 +3,7 @@
 	{{#if themeMarketing}} o-banner--marketing{{/if}}
 	{{#if themeProduct}} o-banner--product{{/if}}
 	{{#if themeCompact}} o-banner--compact{{/if}}
+	{{#if themePikachu}} o-banner--pikachu{{/if}}
 	{{#if small}} o-banner--small{{/if}}"
 	data-n-messaging-component=""
 	data-o-banner-banner-class="{{#if bannerClass}}{{bannerClass}}{{else}}o-banner{{/if}}"

--- a/server/templates/partials/bottom/coronavirus-newsletter-promo.html
+++ b/server/templates/partials/bottom/coronavirus-newsletter-promo.html
@@ -1,0 +1,22 @@
+<div class="n-messaging-client-messaging-banner n-messaging-client-messaging-banner--coronavirus">
+	{{#> n-messaging-client/server/templates/components/o-banner
+		themeCompact=true
+		themePikachu=true
+		renderOpen=true
+	}}
+	<div class="o-banner__inner" data-o-banner-inner="" data-o-banner-inner="">
+		<div class="o-banner__content">
+			<header class="o-banner__heading">
+				<h1><span class="n-messaging-coronavirus__highlight-regular">CORONAVIRUS</span> <span class="n-messaging-coronavirus__highlight-color">BUSINESS UPDATE</span></h1>
+			</header>
+			<p>Get a level-headed briefing with expert input on how markets, global business and our workplaces are being affected, delivered straight to your inbox.</p>
+		</div>
+		<div class="o-banner__actions">
+			<div class="o-banner__action">
+				<a href="https://ep.ft.com/newsletters/5e67775d8bb28f00049b0f76/subscribe"
+					class="o-banner__button">Get the newsletter</a>
+			</div>
+		</div>
+	</div>
+	{{/n-messaging-client/server/templates/components/o-banner}}
+</div>

--- a/server/templates/partials/bottom/coronavirus-newsletter-promo.html
+++ b/server/templates/partials/bottom/coronavirus-newsletter-promo.html
@@ -1,7 +1,7 @@
 <div class="n-messaging-client-messaging-banner n-messaging-client-messaging-banner--coronavirus">
 	{{#> n-messaging-client/server/templates/components/o-banner
 		themeCompact=true
-		themePikachu=true
+		themeSlateLemon=true
 		renderOpen=true
 	}}
 	<div class="o-banner__inner" data-o-banner-inner="" data-o-banner-inner="">


### PR DESCRIPTION
This is identical to the existing Tech Scroll Asia promotion message, with the following changes:

- copy (text)
- newsletter ID in link (coronovirus's instead of Tech Scroll Asia's)
- styling (use slate/lemon colours instead of Tech Scroll Asia's
custom styling)

Desktop:
![image](https://user-images.githubusercontent.com/733849/76417015-021d3680-6394-11ea-93a9-57c3f6305c05.png)

Mobile:
![image](https://user-images.githubusercontent.com/733849/76417079-1b25e780-6394-11ea-8705-9cb1e88d1f42.png)
