### PR TITLE
Fix vertical align of img tag for cross browser compatibility 🐿 v2.12.5

### DIFF
--- a/client/components/o-message-notice.scss
+++ b/client/components/o-message-notice.scss
@@ -26,6 +26,7 @@
 
 	.n-message-notice__image {
 		display: none;
+		vertical-align: top;
 
 		@include oGridRespondTo(M) {
 			display: inline-block;

--- a/server/templates/components/o-message-notice.html
+++ b/server/templates/components/o-message-notice.html
@@ -2,18 +2,22 @@
 	<div class="o-message__container">
 		<div class="o-message__content">
 			<div class="o-message__content-main">
-				<p>
-					<span class="n-message-notice__title">
-						Coronavirus <span class="o-message__content-highlight">business&nbspupdate</span>
-					</span>
-					<span class="n-message-notice__subtitle n-message-notice__subtitle--long">
-						Get 30 days complimentary access to our Coronavirus Business Update newsletter
-					</span>
-					<span class="n-message-notice__subtitle n-message-notice__subtitle--short">
-						30 days complimentary
-					</span>
-				</p>
-				<img class="n-message-notice__image" src="https://www.ft.com/__origami/service/image/v2/images/raw/https%3A%2F%2Fwww.ft.com%2F__assets%2Fcreatives%2Fmessages%2Fcorona-message-desktop.png?source=npm%3A%40financial-times%2Fn-messaging-client" alt="Promotion for Financial Times' Coronavirus Business Update newsletter explaining the Coronavirus' impact on the global financial markets" width="150">
+				<div>
+					<p>
+						<span class="n-message-notice__title">
+							Coronavirus <span class="o-message__content-highlight">business&nbspupdate</span>
+						</span>
+						<span class="n-message-notice__subtitle n-message-notice__subtitle--long">
+							Get 30 days complimentary access to our Coronavirus Business Update newsletter
+						</span>
+						<span class="n-message-notice__subtitle n-message-notice__subtitle--short">
+							30 days complimentary
+						</span>
+					</p>
+				</div>
+				<div>
+					<img class="n-message-notice__image" src="https://www.ft.com/__origami/service/image/v2/images/raw/https%3A%2F%2Fwww.ft.com%2F__assets%2Fcreatives%2Fmessages%2Fcorona-message-desktop.png?source=npm%3A%40financial-times%2Fn-messaging-client" alt="Promotion for Financial Times' Coronavirus Business Update newsletter explaining the Coronavirus' impact on the global financial markets" width="150">
+				</div>
 			</div>
 			<div class="o-message__actions">
 				<a href="https://ft.com/newsletter-signup/coronavirus" class="o-message__actions__primary" data-trackable="coronavirus-newsletter-promo-top">Get the newsletter now</a>


### PR DESCRIPTION
The `img` tag wasn't full height on Firefox. This fixes the issue.