### PR TITLE
Make myFT disengaged tooltip as a permanent feature

### DIFF
--- a/client/components/top/myft-disengaged-tooltip/main.js
+++ b/client/components/top/myft-disengaged-tooltip/main.js
@@ -1,18 +1,19 @@
+// This tooltip should be displayed for users who fill all the requirements below
+// - who are in disengaged cohort (it has been already checked when the decision for displaying this tooltip was made (messageSlotTop flag === 'MyftDisengagedTooltip'))
+// - who haven't followed any topics
+// - who haven't seen the tooltip more than 3 times
+
 import Tooltip from 'o-tooltip';
 import myftClient from 'next-myft-client/myft-bower';
 import {broadcast} from 'n-ui-foundations';
 import Cookies from 'js-cookie';
-import * as flags from '@financial-times/dotcom-ui-flags';
 
 const articleAddToMyftButton = document.querySelector('.topper__primary-theme .n-myft-follow-button');
 const ARTICLE_TOOLTIP_SEEN_COUNT_COOKIE_NAME = 'FT_MyFT_article_tooltip';
-const flagsClient = flags.init();
 let articleTooltipSeenCount = Cookies.get(ARTICLE_TOOLTIP_SEEN_COUNT_COOKIE_NAME) || 0;
 
 export default function customSetup (banner, done) {
-	if(!flagsClient.get('predictedToDisengageCohort') ||
-		!articleAddToMyftButton ||
-		articleTooltipSeenCount >= 3) {
+	if(!articleAddToMyftButton || articleTooltipSeenCount >= 3) {
 		return;
 	}
 
@@ -23,7 +24,10 @@ export default function customSetup (banner, done) {
 }
 
 function showTooltip (followedConcepts, banner) {
-	if (followedConcepts.length > 0) return;
+	if (followedConcepts.length > 0) {
+		return;
+	}
+
 	const topicName = document.querySelector('.topper__primary-theme .js-primary-theme').innerText;
 	const content = [
 		`Find ${topicName} stories easily.`,

--- a/client/components/top/myft-disengaged-tooltip/main.js
+++ b/client/components/top/myft-disengaged-tooltip/main.js
@@ -86,7 +86,7 @@ function showAboutTooltip (banner) {
 	});
 
 
-	if (flagsClient.get('MyFT_DisengagedTooltipsTest')) {
+	if (flagsClient.get('predictedToDisengageCohort')) {
 		const tooltip = new Tooltip(articleAddToMyftButton, {
 			target: 'myft-disengaged-tooltip',
 			content: content,

--- a/client/components/top/myft-disengaged-tooltip/main.js
+++ b/client/components/top/myft-disengaged-tooltip/main.js
@@ -5,69 +5,25 @@ import Cookies from 'js-cookie';
 import * as flags from '@financial-times/dotcom-ui-flags';
 
 const articleAddToMyftButton = document.querySelector('.topper__primary-theme .n-myft-follow-button');
-const headerMyFTLogo = document.querySelector('[data-trackable="my-ft"]');
-const externalReferer = document.referrer && !(new URL(document.referrer).hostname.endsWith('.ft.com'));
 const ARTICLE_TOOLTIP_SEEN_COUNT_COOKIE_NAME = 'FT_MyFT_article_tooltip';
 const flagsClient = flags.init();
 let articleTooltipSeenCount = Cookies.get(ARTICLE_TOOLTIP_SEEN_COUNT_COOKIE_NAME) || 0;
 
 export default function customSetup (banner, done) {
-	if(!externalReferer && articleTooltipSeenCount >= 3) {
+	if(!flagsClient.get('predictedToDisengageCohort') ||
+		!articleAddToMyftButton ||
+		articleTooltipSeenCount >= 3) {
 		return;
-	}
-
-	function handleMyftResponse (followedConcepts) {
-		if (followedConcepts.length && externalReferer) {
-			showHeaderTooltip(banner, followedConcepts);
-		} else if (!followedConcepts.length && articleTooltipSeenCount < 3) {
-			showAboutTooltip(banner);
-		}
 	}
 
 	myftClient.init([{relationship: 'followed', type: 'concept'}])
 		.then(() => myftClient.getAll('followed', 'concept'))
-		.then(handleMyftResponse)
+		.then(followedConcepts => showTooltip(followedConcepts, banner))
 		.finally(() => done());
 }
 
-function showHeaderTooltip (banner, followedConcepts = []) {
-	if (!headerMyFTLogo) return;
-	const concepts = followedConcepts
-		.sort((a, b) => b.lastPublished - a.lastPublished)
-		.map(({name}) => `<span style="white-space: nowrap">${name}</span>`)
-		.slice(0, 3);
-	let content = 'Read the latest ';
-
-	if (concepts.length === 3) {
-		content += `${concepts.shift()}, `;
-	}
-
-	content += concepts.join(' and ');
-	content += ' stories.';
-
-	broadcast('oTracking.event', {
-		action: 'criteria-met',
-		category: 'myft-disengaged-tooltip',
-		detail: {
-			type: 'header-tooltip',
-			followedConceptCount: followedConcepts.length
-		}
-	});
-
-	if (flagsClient.get('MyFT_DisengagedTooltipsTest')) {
-		const tooltip = new Tooltip(headerMyFTLogo, {
-			target: 'myft-disengaged-tooltip',
-			content: content,
-			showOnConstruction: true,
-			position: 'below'
-		});
-		tooltip.tooltipEl.addEventListener('oTooltip.close', () => banner.close());
-	}
-
-}
-
-function showAboutTooltip (banner) {
-	if (!articleAddToMyftButton) return;
+function showTooltip (followedConcepts, banner) {
+	if (followedConcepts.length > 0) return;
 	const topicName = document.querySelector('.topper__primary-theme .js-primary-theme').innerText;
 	const content = [
 		`Find ${topicName} stories easily.`,
@@ -85,16 +41,14 @@ function showAboutTooltip (banner) {
 		}
 	});
 
+	const tooltip = new Tooltip(articleAddToMyftButton, {
+		target: 'myft-disengaged-tooltip',
+		content: content,
+		showOnConstruction: true,
+		position: 'below'
+	});
 
-	if (flagsClient.get('predictedToDisengageCohort')) {
-		const tooltip = new Tooltip(articleAddToMyftButton, {
-			target: 'myft-disengaged-tooltip',
-			content: content,
-			showOnConstruction: true,
-			position: 'below'
-		});
-		articleTooltipSeenCount++;
-		Cookies.set(ARTICLE_TOOLTIP_SEEN_COUNT_COOKIE_NAME, articleTooltipSeenCount, { expires: 365, path: '/content' });
-		tooltip.tooltipEl.addEventListener('oTooltip.close', () => banner.close());
-	}
+	articleTooltipSeenCount++;
+	Cookies.set(ARTICLE_TOOLTIP_SEEN_COUNT_COOKIE_NAME, articleTooltipSeenCount, { expires: 365, path: '/content' });
+	tooltip.tooltipEl.addEventListener('oTooltip.close', () => banner.close());
 }

--- a/client/components/top/myft-disengaged-tooltip/main.js
+++ b/client/components/top/myft-disengaged-tooltip/main.js
@@ -2,12 +2,13 @@ import Tooltip from 'o-tooltip';
 import myftClient from 'next-myft-client/myft-bower';
 import {broadcast} from 'n-ui-foundations';
 import Cookies from 'js-cookie';
+import * as flags from '@financial-times/dotcom-ui-flags';
 
 const articleAddToMyftButton = document.querySelector('.topper__primary-theme .n-myft-follow-button');
 const headerMyFTLogo = document.querySelector('[data-trackable="my-ft"]');
 const externalReferer = document.referrer && !(new URL(document.referrer).hostname.endsWith('.ft.com'));
 const ARTICLE_TOOLTIP_SEEN_COUNT_COOKIE_NAME = 'FT_MyFT_article_tooltip';
-const {FT: {flags = {get: () => {}}} = {}} = window;
+const flagsClient = flags.init();
 let articleTooltipSeenCount = Cookies.get(ARTICLE_TOOLTIP_SEEN_COUNT_COOKIE_NAME) || 0;
 
 export default function customSetup (banner, done) {
@@ -53,7 +54,7 @@ function showHeaderTooltip (banner, followedConcepts = []) {
 		}
 	});
 
-	if (flags.get('MyFT_DisengagedTooltipsTest')) {
+	if (flagsClient.get('MyFT_DisengagedTooltipsTest')) {
 		const tooltip = new Tooltip(headerMyFTLogo, {
 			target: 'myft-disengaged-tooltip',
 			content: content,
@@ -85,7 +86,7 @@ function showAboutTooltip (banner) {
 	});
 
 
-	if (flags.get('MyFT_DisengagedTooltipsTest')) {
+	if (flagsClient.get('MyFT_DisengagedTooltipsTest')) {
 		const tooltip = new Tooltip(articleAddToMyftButton, {
 			target: 'myft-disengaged-tooltip',
 			content: content,

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "webpack-cli": "^3.3.10"
   },
   "dependencies": {
-    "@financial-times/dotcom-ui-flags": "^0.7.3",
     "@financial-times/x-follow-button": "1.0.4",
     "js-cookie": "2.2.0"
   }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "webpack-cli": "^3.3.10"
   },
   "dependencies": {
+    "@financial-times/dotcom-ui-flags": "^0.7.3",
     "@financial-times/x-follow-button": "1.0.4",
     "js-cookie": "2.2.0"
   }


### PR DESCRIPTION
myFT tooltip AB test for disengaged users was successful.
We are going to roll this out to 100% of users who fall into the predicted to disengage cohort.
However, the tooltip which encouraged users to visit myFT feed was not conclusive, we will not be rolling this out.

[Jira ticket](https://financialtimes.atlassian.net/browse/CON-130)

**Release** 👇 

<img width="821" alt="Screenshot 2020-04-28 at 15 32 10" src="https://user-images.githubusercontent.com/21194161/80511587-35337d80-8974-11ea-9bd5-4c4e190b20dd.png">

The tooltip is displayed for users who fill **All** the requirements below
- Users who are in disengaged cohort
- Users who haven't followed any topics
- Users who haven't seen the tooltip more than 3 times


**Kill** 👇 

<img width="1024" alt="Screenshot 2020-04-27 at 15 32 10" src="https://user-images.githubusercontent.com/21194161/80511659-4da39800-8974-11ea-98c1-82d8e8c8c4ce.png">

The tooltip was displayed for users who filled **All** the requirements below
- Users who are in disengaged cohort
- Users who visit articles via non-ft site
- Users who have followed concepts
- Users who haven't seen the tooltip more than 3 times
