### PR TITLE
ACQ-239 Use cookie to show or hide marketing popup prompt message

### DIFF
--- a/client/components/bottom/marketing-popup-prompt/main.js
+++ b/client/components/bottom/marketing-popup-prompt/main.js
@@ -1,0 +1,16 @@
+const cookies = require('js-cookie');
+
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+const POPUP_PROMPT_COOKIE_NAME = 'popupPromptShown';
+
+export default function (banner, done) {
+	const timeSet = cookies.get(POPUP_PROMPT_COOKIE_NAME);
+
+	if (timeSet === undefined) {
+		const expiryDate = new Date(new Date().getTime() + 10 * ONE_DAY_MS);
+		cookies.set(POPUP_PROMPT_COOKIE_NAME, 'OK', { domain: 'ft.com', expires: expiryDate });
+		banner.open();
+	}
+
+	return done({ skip: true });
+}

--- a/manifest.js
+++ b/manifest.js
@@ -19,7 +19,7 @@ module.exports = {
 		path: 'bottom/swg-entitlements-prompt'
 	},
 	marketingPopupPrompt: {
-		path: 'bottom/lazy',
+		path: 'bottom/marketing-popup-prompt',
 		lazy: true,
 		guruQueryString: 'offerId=d6b1bd32-1bd6-368b-78c5-62793ee43e7a',
 		trackingContext: {

--- a/server/templates/partials/bottom/marketing-popup-prompt.html
+++ b/server/templates/partials/bottom/marketing-popup-prompt.html
@@ -1,0 +1,1 @@
+<div data-n-messaging-component=""></div>


### PR DESCRIPTION
Ammit doesn't use messaging data for unregistered users. Marketing Popup Prompt doesn't hide for 10 days after showing as a result. This PR uses a cookie with 10 day expiry to dismiss the notice instead of using Ammit.

## Advantges of this approach

The implementation is quite straight forward and doesn't add complexity to the Ammit code.

## Disadvantges of this approach

A user won't see lower priority messages instead of popup prompt when it is hidden because Ammit doesn't know that it is being hidden.

## Other solutions

Start of Ammit modification solution: https://github.com/Financial-Times/next-ammit-api/pull/671