### PR TITLE
ACQ-239 Drop popup prompt cookie only when dismiss button clicked

### DIFF
--- a/client/components/bottom/marketing-popup-prompt/main.js
+++ b/client/components/bottom/marketing-popup-prompt/main.js
@@ -7,10 +7,14 @@ export default function (banner, done) {
 	const timeSet = cookies.get(POPUP_PROMPT_COOKIE_NAME);
 
 	if (timeSet === undefined) {
-		const expiryDate = new Date(new Date().getTime() + 10 * ONE_DAY_MS);
-		cookies.set(POPUP_PROMPT_COOKIE_NAME, 'OK', { domain: 'ft.com', expires: expiryDate });
 		banner.open();
 	}
+
+	const closeButton = banner.bannerElement.querySelector('.o-banner__close');
+	closeButton.addEventListener('click', function addCookie () {
+		const expiryDate = new Date(new Date().getTime() + 10 * ONE_DAY_MS);
+		cookies.set(POPUP_PROMPT_COOKIE_NAME, 'OK', { domain: 'ft.com', expires: expiryDate });
+	});
 
 	return done({ skip: true });
 }

--- a/secret-squirrel.js
+++ b/secret-squirrel.js
@@ -16,7 +16,8 @@ module.exports = {
 			'2a6a4586-ace0-6465-aebe-aa1ecc543271', // server/templates/partials/bottom/us-election-2020-promo.html:16
 			'5f60b8b4-cbf0-18d7-df41-9caa1171e8c1', // server/templates/partials/top/anon-subscribe-now.html:5|18
 			'a44c9005-2a9c-fe2a-9140-1311ff87f25f', // server/templates/partials/top/print-banner-usa.html:4
-			'79c8c0c5-1686-7f28-3aeb-c14688d59749' // server/templates/partials/top/uk-election.html:4
+			'79c8c0c5-1686-7f28-3aeb-c14688d59749', // server/templates/partials/top/uk-election.html:4
+			'info@companyx.com', // docs/corporate-cancellation-message.md:31|36
 		]
 	}
 };


### PR DESCRIPTION
Original behaviour was to hide the marketing pop up prompt after it has been shown once, regardless of user interaction.

This PR changes the behaviour so the cookie hiding the prompt is only dropped when the user dismisses the prompt.