### PR TITLE
add accessibility text for cookie consent links 🐿 v2.13.0

### DIFF
--- a/server/templates/partials/bottom/cookie-consent.html
+++ b/server/templates/partials/bottom/cookie-consent.html
@@ -8,7 +8,7 @@
 	}}
 	<h2 class="cookie-banner__head" id="cookie-banner-aria-label">Cookies on FT Sites</h2>
 	<div class="cookie-banner__inner" data-o-banner-inner="" data-o-banner-inner="">
-		<div id="cookie-banner-aria-description">We use <a href="http://help.ft.com/help/legal-privacy/cookies/" class="cookie-banner__link cookie-banner__link--external" data-o-banner-action data-o-banner-action-type="view-policy" target="_blank" rel="noopener">cookies</a> for a number of reasons, such as keeping FT Sites reliable and secure, personalising content and ads, providing social media features and to analyse how our Sites are used.</div>
+		<div id="cookie-banner-aria-description">We use <a href="http://help.ft.com/help/legal-privacy/cookies/" class="cookie-banner__link cookie-banner__link--external" data-o-banner-action data-o-banner-action-type="view-policy" target="_blank" rel="noopener">cookies <span class="o-normalise-visually-hidden">opens in new window</span></a> for a number of reasons, such as keeping FT Sites reliable and secure, personalising content and ads, providing social media features and to analyse how our Sites are used.</div>
 		<div class="cookie-banner__actions">
 			<div>
 				<a class="cookie-banner__link" href="https://www.ft.com/preferences/manage-cookies" data-o-banner-action data-o-banner-action-type="manage">Manage cookies</a>

--- a/server/templates/partials/bottom/cookie-consent.html
+++ b/server/templates/partials/bottom/cookie-consent.html
@@ -8,7 +8,7 @@
 	}}
 	<h2 class="cookie-banner__head" id="cookie-banner-aria-label">Cookies on FT Sites</h2>
 	<div class="cookie-banner__inner" data-o-banner-inner="" data-o-banner-inner="">
-		<div id="cookie-banner-aria-description">We use <a href="http://help.ft.com/help/legal-privacy/cookies/" class="cookie-banner__link cookie-banner__link--external" data-o-banner-action data-o-banner-action-type="view-policy" target="_blank" rel="noopener">cookies <span class="o-normalise-visually-hidden">opens in new window</span></a> for a number of reasons, such as keeping FT Sites reliable and secure, personalising content and ads, providing social media features and to analyse how our Sites are used.</div>
+		<div id="cookie-banner-aria-description">We use <a href="http://help.ft.com/help/legal-privacy/cookies/" class="cookie-banner__link cookie-banner__link--external" data-o-banner-action data-o-banner-action-type="view-policy" target="_blank" rel="noopener">cookies<span class="o-normalise-visually-hidden"> (opens in new window)</span></a> for a number of reasons, such as keeping FT Sites reliable and secure, personalising content and ads, providing social media features and to analyse how our Sites are used.</div>
 		<div class="cookie-banner__actions">
 			<div>
 				<a class="cookie-banner__link" href="https://www.ft.com/preferences/manage-cookies" data-o-banner-action data-o-banner-action-type="manage">Manage cookies</a>


### PR DESCRIPTION
This ads text to indicate to users that the "cookies" link on the cookie consent popup opens in a new window