### PR TITLE
Update n-ui-foundations ^4.0.0 -> ^6.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,11 +99,14 @@ if ( window.FT.flags.messageSlotBottom || window.FT.flags.messageSlotTop ) {
 
 ## Running locally
 
-- `make install`
-- `make demo-certs` (to install self-signed SSL cert for HTTPS support, otherwise most service calls such as myFT will not work due to secure cookies)
-- `make demo-watch` (will build, run and watch the demo)
--  visit https://local.ft.com:5005 (make sure you are on `ft.com` so that toggler cookies are used)
--  before opening a PR, please run `make verify` to check things like linting
+1. `make install`
+2. `make demo-certs` (to install self-signed SSL cert for HTTPS support, otherwise most service calls such as myFT will not work due to secure cookies)
+3. `make demo-watch` (will build, run and watch the demo)
+4.  [configure a message to show](#viewing-messages)
+5.  visit https://local.ft.com:5005 (make sure you are on `ft.com` so that toggler cookies are used)
+
+
+Note: before opening a PR, please run `make verify` to check things like linting
 	-  in order to see and fix linting errors, please make sure you have Editor Config and ES Lint plugins installed on your editor of choice
 
 ## Configuring Messages

--- a/bower.json
+++ b/bower.json
@@ -30,7 +30,7 @@
     "secret-squirrel.js"
   ],
   "dependencies": {
-    "n-ui-foundations": "^4.0.0-beta.1",
+    "n-ui-foundations": "^6.0.0",
     "o-banner": "^3.3.0",
     "o-share": "^7.0.0",
     "o-tooltip": "^4.0.0",
@@ -41,7 +41,7 @@
     "o-overlay": "^3.0.0",
     "o-loading": "^4.0.0",
     "o-tracking": "^2.0.6",
-    "n-myft-ui": "^21.2.0",
+    "n-myft-ui": "^22.0.0",
     "n-swg": "^2.1.1"
   }
 }


### PR DESCRIPTION
Jira card: https://financialtimes.atlassian.net/secure/RapidBoard.jspa?rapidView=1051&modal=detail&selectedIssue=CPP-89.

This PR upgrades the version of its `n-ui-foundations` bower dependency.

It also upgrades the version of its `n-myft-ui` bower dependency to a version that uses the same `n-ui-foundations` version (v6.0.0), as it too has a dependency on that package.

I have also updated the README as I was confused for a while trying to get the messaging components to appear and didn't immediately realise you needed to turn them on in toggler.