### PR TITLE
ACQ-279 Remaining articles tracking

### DIFF
--- a/client/bottom-slot.js
+++ b/client/bottom-slot.js
@@ -13,14 +13,22 @@ const BOTTOM_SLOT_FLAG = 'messageSlotBottom';
 
 module.exports = function ({ config={}, guruResult, customSetup }={}) {
 	let banner;
-	const variant = (guruResult && guruResult.renderData && guruResult.renderData.dynamicTrackingData) || config.name;
+	const guruRenderData = guruResult && guruResult.renderData || {};
+	const variant = (guruRenderData && guruResult.renderData.dynamicTrackingData) || config.name;
+
+	const trackingContext = Object.assign(
+		config.trackingContext || {},
+		guruRenderData && guruResult.renderData.trackingContext || {},
+	);
+
 	const trackEventAction = config.name && generateMessageEvent({
 		flag: BOTTOM_SLOT_FLAG,
 		messageId: config.name,
 		position: config.slot,
-		trackingContext: config.trackingContext,
+		trackingContext,
 		variant
 	});
+
 	const declarativeElement = !config.lazy && config.content;
 
 	if (declarativeElement) {

--- a/client/utils.js
+++ b/client/utils.js
@@ -38,7 +38,7 @@ const updateMessageEventCount = (messageId, event) => {
 
 module.exports = {
 	generateMessageEvent: function ({ messageId, position, flag, trackingContext, variant }={}) {
-		return function (action, trackingAttr, dynamicContext = {}) {
+		return function (action, trackingAttr) {
 			const detail = Object.assign({
 				category: 'n-messaging',
 				action: action,
@@ -47,8 +47,7 @@ module.exports = {
 				messaging_flag: flag,
 				messaging_variant: variant
 			},
-			trackingContext,
-			dynamicContext,
+			trackingContext
 			);
 
 			if (trackingAttr)


### PR DESCRIPTION
The remaining articles bottom slot message has different tracking context depending on the response from messaging guru.

This PR looks for a `trackingContext` key in the barrier guru response and adds it to the configuration tracking context if it exists. This allows for dynamic tracking events to be generated.

An example implementation in messaging guru is here: https://github.com/Financial-Times/next-messaging-guru/pull/96