### PR TITLE
Change conditional to hide message when less than 0 remaining 🐿 v2.13.0

### DIFF
--- a/client/components/bottom/remaining-articles/main.js
+++ b/client/components/bottom/remaining-articles/main.js
@@ -1,5 +1,5 @@
 export default function customSetup (banner, done, guruResult) {
-	if (guruResult.renderData.remainingArticles <= 0) {
+	if (guruResult.renderData.remainingArticles < 0) {
 		return;
 	}
 


### PR DESCRIPTION
Users will see a final 'This is your last article' message before being shown the paywall.

This changes the message to show only when there are fewer than 0 articles left instead of fewer than 1.