### PR TITLE
Improve the accessibility of the close button on banners - NOPS-257

### DIFF
--- a/server/templates/components/o-banner.html
+++ b/server/templates/components/o-banner.html
@@ -9,7 +9,8 @@
 	data-o-banner-banner-class="{{#if bannerClass}}{{bannerClass}}{{else}}o-banner{{/if}}"
 	data-o-banner-auto-open="false"
 	{{#if suppressCloseButton}} data-o-banner-suppress-close-button="true"{{/if}}
-	>
+	{{#if closeLabel}} data-o-banner-close-button-label="{{closeLabel}}"{{/if}}
+>
 	<div class="o-banner__outer">
 		{{#if @partial-block}}
 			{{{@partial-block}}}

--- a/server/templates/partials/bottom/app-promo-mobile.html
+++ b/server/templates/partials/bottom/app-promo-mobile.html
@@ -1,6 +1,7 @@
 <div class="n-messaging-client-messaging-banner n-messaging-client-messaging-banner--app-promo-mobile">
 	{{#> n-messaging-client/server/templates/components/o-banner
 		renderOpen=true
+		closeLabel="Close the FT app promotional banner"
 	}}
 	<div class="o-banner__inner" data-o-banner-inner="" data-o-banner-inner="">
 		<!-- Content to display on larger screens -->

--- a/server/templates/partials/bottom/b2b-trial-contact-us.html
+++ b/server/templates/partials/bottom/b2b-trial-contact-us.html
@@ -3,6 +3,7 @@
 			renderOpen=true
 			themeMarketing=true
 			small=true
+			closeLabel="Close the 'Make informed business decisions' banner"
 		}}
 		<div class="o-banner__inner" data-o-banner-inner="" data-o-banner-inner="">
 			<header class="o-banner__heading">

--- a/server/templates/partials/bottom/b2b-trial-mobile.html
+++ b/server/templates/partials/bottom/b2b-trial-mobile.html
@@ -1,5 +1,6 @@
 <div class="n-messaging-client-messaging-banner--b2b-trial-mobile">
 	{{#> n-messaging-client/server/templates/components/o-banner
+			closeLabel="Close the FT app promotional banner"
 	}}
 	<div class="o-banner__inner" data-o-banner-inner="" data-o-banner-inner="">
 		<!-- Content to display on larger screens -->

--- a/server/templates/partials/bottom/book-your-consult.html
+++ b/server/templates/partials/bottom/book-your-consult.html
@@ -3,6 +3,7 @@
 			renderOpen=true
 			themeMarketing=true
 			small=true
+			closeLabel="Close the 'Book a free consultation with your customer success manager' banner"
 		}}
 		<div class="o-banner__inner" data-o-banner-inner="" data-o-banner-inner="">
 			<header class="o-banner__heading">

--- a/server/templates/partials/bottom/content-message.html
+++ b/server/templates/partials/bottom/content-message.html
@@ -2,6 +2,7 @@
 	{{#> n-messaging-client/server/templates/components/o-banner
 		themeCompact=true
 		renderOpen=true
+		closeLabel="Close the 4-week trial promotional banner"
 	}}
 	<div class="o-banner__inner" data-o-banner-inner="" data-o-banner-inner="">
 		<div class="o-banner__content">

--- a/server/templates/partials/bottom/coronavirus-newsletter-promo.html
+++ b/server/templates/partials/bottom/coronavirus-newsletter-promo.html
@@ -3,6 +3,7 @@
 		themeCompact=true
 		themeSlateLemon=true
 		renderOpen=true
+		closeLabel="Close the 'Coronavirus business update' banner"
 	}}
 	<div class="o-banner__inner" data-o-banner-inner="" data-o-banner-inner="">
 		<div class="o-banner__content">

--- a/server/templates/partials/bottom/daily-digest.html
+++ b/server/templates/partials/bottom/daily-digest.html
@@ -1,6 +1,7 @@
 <div class="n-messaging-client-messaging-banner">
 		{{#> n-messaging-client/server/templates/components/o-banner
 			renderOpen=true
+			closeLabel="Close the 'sign up to the myFT daily digest' banner"
 		}}
 		<div class="o-banner__inner" data-o-banner-inner="" data-o-banner-inner="">
 			<div class="o-banner__content">

--- a/server/templates/partials/bottom/fast-ft.html
+++ b/server/templates/partials/bottom/fast-ft.html
@@ -2,6 +2,7 @@
 	{{#> n-messaging-client/server/templates/components/o-banner
 		themeCompact=true
 		renderOpen=true
+		closeLabel="Close the fastFT promotional banner"
 	}}
 	<div class="o-banner__inner" data-o-banner-inner="" data-o-banner-inner="">
 		<div class="o-banner__content">

--- a/server/templates/partials/bottom/markets-data.html
+++ b/server/templates/partials/bottom/markets-data.html
@@ -2,6 +2,7 @@
 	{{#> n-messaging-client/server/templates/components/o-banner
 		themeCompact=true
 		renderOpen=true
+		closeLabel="Close the Markets data promotional banner"
 	}}
 	<div class="o-banner__inner" data-o-banner-inner="" data-o-banner-inner="">
 		<div class="o-banner__content">

--- a/server/templates/partials/bottom/onboarding-myft.html
+++ b/server/templates/partials/bottom/onboarding-myft.html
@@ -1,6 +1,7 @@
 <div class="n-messaging-client-messaging-banner">
 		{{#> n-messaging-client/server/templates/components/o-banner
 			renderOpen=true
+			closeLabel="Close the myFT promotional banner"
 		}}
 		<div class="o-banner__inner" data-o-banner-inner="" data-o-banner-inner="">
 			<div class="o-banner__content">

--- a/server/templates/partials/bottom/onboarding-premium.html
+++ b/server/templates/partials/bottom/onboarding-premium.html
@@ -1,6 +1,7 @@
 <div class="n-messaging-client-messaging-banner">
 		{{#> n-messaging-client/server/templates/components/o-banner
 			renderOpen=true
+			closeLabel="Close the premium subscription promotional banner"
 		}}
 		<div class="o-banner__inner" data-o-banner-inner="" data-o-banner-inner="">
 			<div class="o-banner__content">

--- a/server/templates/partials/bottom/oneclick-daily-digest.html
+++ b/server/templates/partials/bottom/oneclick-daily-digest.html
@@ -1,5 +1,9 @@
 <div class="n-messaging-client-messaging-banner">
-	{{#> n-messaging-client/server/templates/components/o-banner renderOpen=true small=true }}
+	{{#> n-messaging-client/server/templates/components/o-banner
+		renderOpen=true
+		small=true
+		closeLabel="Close the 'Sign up to the myFT daily digest' banner"
+	}}
 	<!-- front banner -->
 	<div class="o-banner__inner" data-o-banner-inner data-n-messaging-daily-digest-front>
 		<div class="o-banner__content">

--- a/server/templates/partials/bottom/secondary-school-survey.html
+++ b/server/templates/partials/bottom/secondary-school-survey.html
@@ -1,6 +1,7 @@
 {{#> n-messaging-client/server/templates/components/o-banner
 	themeMarketing="true"
 	small="true"
+	closeLabel="Close the 'How do you rate FT Schools?' banner"
 }}
 	<div class="o-banner__inner">
 		<!-- Content to display on larger screens -->

--- a/server/templates/partials/bottom/tbyb-in-trial-subscribe.html
+++ b/server/templates/partials/bottom/tbyb-in-trial-subscribe.html
@@ -3,6 +3,7 @@
 		themeSlateLemon=true
 		renderOpen=true
 		small=true
+		closeLabel="Close the 'Enjoying the free trial?' banner"
 	}}
 	<div class="o-banner__inner" data-o-banner-inner="" data-o-banner-inner="">
 		<div class="o-banner__content">

--- a/server/templates/partials/bottom/tbyb-post-trial-subscribe.html
+++ b/server/templates/partials/bottom/tbyb-post-trial-subscribe.html
@@ -3,6 +3,7 @@
 		themeSlateLemon=true
 		renderOpen=true
 		small=true
+		closeLabel="Close the 'Continue reading with a subscription' banner"
 	}}
 	<div class="o-banner__inner" data-o-banner-inner="" data-o-banner-inner="">
 		<div class="o-banner__content">

--- a/server/templates/partials/bottom/tech-scroll-asia.html
+++ b/server/templates/partials/bottom/tech-scroll-asia.html
@@ -2,6 +2,7 @@
 	{{#> n-messaging-client/server/templates/components/o-banner
 		themeCompact=true
 		renderOpen=true
+		closeLabel="Close the 'Introducing Tech Scroll Asia' banner"
 	}}
 	<div class="o-banner__inner" data-o-banner-inner="" data-o-banner-inner="">
 		<div class="o-banner__content">

--- a/server/templates/partials/bottom/us-election-2020-promo.html
+++ b/server/templates/partials/bottom/us-election-2020-promo.html
@@ -2,6 +2,7 @@
 	{{#> n-messaging-client/server/templates/components/o-banner
 		themeCompact=true
 		renderOpen=true
+		closeLabel="Close the 'Save 25% for annual Digital access' banner"
 	}}
 	<div class="o-banner__inner" data-o-banner-inner="">
 		<div class="o-banner__content">


### PR DESCRIPTION
The `close-button-label` option will be passed through to o-banner if a `closeLabel` parameter exists.

This will improve the accessibility of the close button as screen reader users will be given the context they need to decide if they want to close the banner.

<img width="1084" alt="Screenshot of o-banner markup including the extra close label" src="https://user-images.githubusercontent.com/524573/86770840-3aced300-c049-11ea-9fab-fcc8c25c6600.png">

I have added a close label to each banner, I am new to most of these banners so I have tried to use my best judgement for the wording but I am open to better suggestions

