### PR TITLE
ACQ-342 Check whether message is lazy loaded when setting declarativeElement

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Messaging slot ammit "flags" use "Brain™" logic to decide which variant to pic
 ### Under the hood :wrench:
 
 - The "bottom" message slot uses [`o-banner`](http://registry.origami.ft.com/components/o-banner)
-- The "top" message slot uses [o-message`](http://registry.origami.ft.com/components/o-message)
+- The "top" message slot uses [`o-message`](http://registry.origami.ft.com/components/o-message)
 
 ### Releasing a message to production
 

--- a/client/top-slot.js
+++ b/client/top-slot.js
@@ -27,7 +27,6 @@ function getServerRenderedBanner (config, guruResult) {
 }
 
 module.exports = function ({ config={}, guruResult, customSetup }={}) {
-	let alertBanner;
 	const variant = (guruResult && guruResult.renderData && guruResult.renderData.dynamicTrackingData) || config.name;
 	const trackEventAction = config.name && generateMessageEvent({
 		flag: TOP_SLOT_FLAG,
@@ -36,19 +35,16 @@ module.exports = function ({ config={}, guruResult, customSetup }={}) {
 		trackingContext: config.trackingContext,
 		variant: variant
 	});
-	const declarativeElement = !config.lazy && getServerRenderedBanner(config, guruResult);
+	const declarativeElement = getServerRenderedBanner(config, guruResult);
 	const options = { messageClass: ALERT_BANNER_CLASS, autoOpen: false, close: message.getDataAttributes(declarativeElement).close};
 
-	if (declarativeElement) {
-		alertBanner = new message(declarativeElement, options);
-	} else if (guruResult && guruResult.renderData) {
-		alertBanner = new message(null, imperativeOptions(guruResult.renderData, options));
-	} else {
-		if (guruResult.skip && trackEventAction) {
-			trackEventAction('skip');
-		}
+	if (guruResult && guruResult.skip && trackEventAction) {
+		trackEventAction('skip');
 		return;
 	}
+
+	const allOptions = imperativeOptions(guruResult ? guruResult.renderData : {}, options);
+	const alertBanner = new message(declarativeElement, allOptions);
 
 	if (messageEventLimitsBreached(config.name)) {
 		trackEventAction('skip'); // todo do we actually need to do this?

--- a/client/top-slot.js
+++ b/client/top-slot.js
@@ -43,7 +43,8 @@ module.exports = function ({ config={}, guruResult, customSetup }={}) {
 		return;
 	}
 
-	const allOptions = imperativeOptions(guruResult ? guruResult.renderData : {}, options);
+	const guruRenderData = guruResult && guruResult.renderData || {};
+	const allOptions = imperativeOptions(guruRenderData, options);
 	const alertBanner = new message(declarativeElement, allOptions);
 
 	if (messageEventLimitsBreached(config.name)) {

--- a/client/top-slot.js
+++ b/client/top-slot.js
@@ -7,6 +7,7 @@ const ALERT_ACTION_SELECTOR = '[data-o-message-action]';
 const ALERT_BANNER_BUTTON_SELECTOR = `.${ALERT_BANNER_CLASS}__button`;
 const ALERT_BANNER_LINK_SELECTOR = `.${ALERT_BANNER_CLASS}__link`;
 
+const TOP_SLOT_CONTENT_SELECTOR = '[data-n-messaging-slot="top"] [data-n-messaging-component]';
 const TOP_SLOT_FLAG = 'messageSlotTop';
 
 function getServerRenderedBanner (config, guruResult) {
@@ -100,7 +101,7 @@ function imperativeOptions (opts, defaults) {
 		messageClass: opts.messageClass || defaults.messageClass,
 		type: opts.type,
 		status: opts.status,
-		parentElement: opts.parentElement,
+		parentElement: opts.parentElement || TOP_SLOT_CONTENT_SELECTOR,
 		content: {
 			highlight: opts.contentTitle,
 			detail: opts.content,

--- a/client/top-slot.js
+++ b/client/top-slot.js
@@ -100,7 +100,6 @@ function imperativeOptions (opts, defaults) {
 		autoOpen: opts.autoOpen || defaults.autoOpen,
 		messageClass: opts.messageClass || defaults.messageClass,
 		type: opts.type,
-		status: opts.status,
 		parentElement: opts.parentElement || TOP_SLOT_CONTENT_SELECTOR,
 		content: {
 			highlight: opts.contentTitle,

--- a/client/top-slot.js
+++ b/client/top-slot.js
@@ -117,5 +117,7 @@ function imperativeOptions (opts, defaults) {
 			}
 		},
 		close: opts.closeButton,
+		dynamicTrackingData: opts.dynamicTrackingData,
+		state: opts.state,
 	};
 }

--- a/client/top-slot.js
+++ b/client/top-slot.js
@@ -35,7 +35,7 @@ module.exports = function ({ config={}, guruResult, customSetup }={}) {
 		trackingContext: config.trackingContext,
 		variant: variant
 	});
-	const declarativeElement = getServerRenderedBanner(config, guruResult);
+	const declarativeElement = !config.lazy && getServerRenderedBanner(config, guruResult);
 	const options = { messageClass: ALERT_BANNER_CLASS, autoOpen: false, close: message.getDataAttributes(declarativeElement).close};
 
 	if (declarativeElement) {
@@ -117,6 +117,5 @@ function imperativeOptions (opts, defaults) {
 			}
 		},
 		close: opts.closeButton,
-		dynamicTrackingData: opts.dynamicTrackingData
 	};
 }


### PR DESCRIPTION
`n-messaging-client` is able to lazy load messages. This works for the bottom slot with examples in production. It looks like lazy loaded top slot messages haven't been used for a while and aren't working.

When trying to lazy load a message in the top slot nothing is rendered, only the placeholder template shows. This pull request fixes the client logic to check whether the message should be lazy loaded or not when deciding how to render using `o-message`. It also adds parameters passed to `o-message` to allow the message to load and attach to the correct parent element.

I imagine the logic can be simplified further to reflect how bottom slot messages are loaded. This is an initial fix.