### PR TITLE
fix: provide fallback o-message type 🐿 v2.12.5

### DIFF
--- a/client/top-slot.js
+++ b/client/top-slot.js
@@ -36,7 +36,12 @@ module.exports = function ({ config={}, guruResult, customSetup }={}) {
 		variant: variant
 	});
 	const declarativeElement = getServerRenderedBanner(config, guruResult);
-	const options = { messageClass: ALERT_BANNER_CLASS, autoOpen: false, close: message.getDataAttributes(declarativeElement).close};
+	const options = {
+		messageClass: ALERT_BANNER_CLASS,
+		autoOpen: false,
+		close: message.getDataAttributes(declarativeElement).close,
+		type: 'notice'
+	};
 
 	if (guruResult && guruResult.skip && trackEventAction) {
 		trackEventAction('skip');
@@ -96,7 +101,7 @@ function imperativeOptions (opts, defaults) {
 	return {
 		autoOpen: opts.autoOpen || defaults.autoOpen,
 		messageClass: opts.messageClass || defaults.messageClass,
-		type: opts.type,
+		type: opts.type || defaults.type,
 		parentElement: opts.parentElement || TOP_SLOT_CONTENT_SELECTOR,
 		content: {
 			highlight: opts.contentTitle,


### PR DESCRIPTION
Errors are currently being thrown on front-page:

```
/__assets/hashed/page-kit/n-messaging-client.784e097f3c9c.bundle.js:1 Error: *** o-message error:
Messages require a type. Available types are:
- action
- alert
- notice
***
    at s (/__assets/hashed/page-kit/o-message.f00f50548094.bundle.js:1)
    at t.value (/__assets/hashed/page-kit/o-message.f00f50548094.bundle.js:1)
    at new t (/__assets/hashed/page-kit/o-message.f00f50548094.bundle.js:1)
    at e.exports (/__assets/hashed/page-kit/n-messaging-client.784e097f3c9c.bundle.js:1)
    at async Promise.all (/index 0)
```

