### PR TITLE
fix: don't provide parent element if message is NOT lazy

### DIFF
--- a/client/top-slot.js
+++ b/client/top-slot.js
@@ -50,7 +50,7 @@ module.exports = function ({ config={}, guruResult, customSetup }={}) {
 	}
 
 	const guruRenderData = guruResult && guruResult.renderData || {};
-	const allOptions = imperativeOptions(guruRenderData, options);
+	const allOptions = imperativeOptions(guruRenderData, options, config);
 	const alertBanner = new message(declarativeElement, allOptions);
 
 	if (messageEventLimitsBreached(config.name)) {
@@ -98,12 +98,12 @@ module.exports = function ({ config={}, guruResult, customSetup }={}) {
 
 };
 
-function imperativeOptions (opts, defaults) {
+function imperativeOptions (opts, defaults, config) {
 	return {
 		autoOpen: opts.autoOpen || defaults.autoOpen,
 		messageClass: opts.messageClass || defaults.messageClass,
 		type: opts.type || defaults.type,
-		parentElement: opts.parentElement || TOP_SLOT_CONTENT_SELECTOR,
+		parentElement: config.lazy ? opts.parentElement || TOP_SLOT_CONTENT_SELECTOR : null,
 		content: {
 			highlight: opts.contentTitle,
 			detail: opts.content,

--- a/package.json
+++ b/package.json
@@ -1,44 +1,48 @@
 {
-	"name": "@financial-times/n-messaging-client",
-	"version": "0.0.0",
-	"repository": "Financial-Times/n-messaging-client",
-	"description": "Lightweight first party messaging for use with \"The Brain\"",
-	"main": "main-server.js",
-	"scripts": {
-		"precommit": "node_modules/.bin/secret-squirrel",
-		"commitmsg": "node_modules/.bin/secret-squirrel-commitmsg",
-		"prepush": "make verify -j3",
-		"prepare": "npx snyk protect || npx snyk protect -d || true"
-	},
-	"license": "MIT",
-	"x-dash": {
-		"engine": {
-			"browser": "preact"
-		}
-	},
-	"devDependencies": {
-		"@financial-times/dotcom-server-handlebars": "2.2.0",
-		"@financial-times/n-gage": "6.2.1",
-		"bower": "^1.8.8",
-		"chai": "^4.1.2",
-		"cookie-parser": "^1.4.4",
-		"eslint": "^6.8.0",
-		"eslint-plugin-react": "^7.18.3",
-		"express": "^4.17.1",
-		"mocha": "^5.2.0",
-		"node-sass": "^4.13.1",
-		"nodemon": "^1.17.5",
-		"postcss": "^7.0.26",
-		"preact": "^8.5.3",
-		"request": "^2.87.0",
-		"sinon": "^6.0.0",
-		"snyk": "^1.168.0",
-		"sucrase": "^3.12.1",
-		"webpack": "^4.41.5",
-		"webpack-cli": "^3.3.10"
-	},
-	"dependencies": {
-		"@financial-times/x-follow-button": "1.0.4",
-		"js-cookie": "2.2.0"
-	}
+  "name": "@financial-times/n-messaging-client",
+  "version": "0.0.0",
+  "repository": "Financial-Times/n-messaging-client",
+  "description": "Lightweight first party messaging for use with \"The Brain\"",
+  "main": "main-server.js",
+  "scripts": {
+    "prepare": "npx snyk protect || npx snyk protect -d || true"
+  },
+  "license": "MIT",
+  "x-dash": {
+    "engine": {
+      "browser": "preact"
+    }
+  },
+  "devDependencies": {
+    "@financial-times/dotcom-server-handlebars": "2.2.0",
+    "@financial-times/n-gage": "6.2.1",
+    "bower": "^1.8.8",
+    "chai": "^4.1.2",
+    "cookie-parser": "^1.4.4",
+    "eslint": "^6.8.0",
+    "eslint-plugin-react": "^7.18.3",
+    "express": "^4.17.1",
+    "mocha": "^5.2.0",
+    "node-sass": "^4.13.1",
+    "nodemon": "^1.17.5",
+    "postcss": "^7.0.26",
+    "preact": "^8.5.3",
+    "request": "^2.87.0",
+    "sinon": "^6.0.0",
+    "snyk": "^1.168.0",
+    "sucrase": "^3.12.1",
+    "webpack": "^4.41.5",
+    "webpack-cli": "^3.3.10"
+  },
+  "dependencies": {
+    "@financial-times/x-follow-button": "1.0.4",
+    "js-cookie": "2.2.0"
+  },
+  "husky": {
+    "hooks": {
+      "commit-msg": "node_modules/.bin/secret-squirrel-commitmsg",
+      "pre-commit": "node_modules/.bin/secret-squirrel",
+      "pre-push": "make verify -j3"
+    }
+  }
 }

--- a/server/templates/components/o-message.html
+++ b/server/templates/components/o-message.html
@@ -1,4 +1,4 @@
-<div class="o-message n-messaging-client-alert-banner o-message--alert{{#unless renderOpen}} o-message--closed{{/unless}} o-message--{{theme}} n-messaging-client-alert-banner--{{theme}}{{#if customClass}} {{customClass}}{{/if}}" data-close="{{closeButton}}" data-n-messaging-component="" data-o-message-auto-open="false" {{#if customDataTrackableBanner}}data-trackable="{{customDataTrackableBanner}}"{{/if}}>
+<div data-o-component=o-message class="o-message n-messaging-client-alert-banner o-message--alert{{#unless renderOpen}} o-message--closed{{/unless}} o-message--{{theme}} n-messaging-client-alert-banner--{{theme}}{{#if customClass}} {{customClass}}{{/if}}" data-close="{{closeButton}}" data-n-messaging-component="" data-o-message-auto-open="false" {{#if customDataTrackableBanner}}data-trackable="{{customDataTrackableBanner}}"{{/if}}>
 	<div class="o-message__container">
 		<div class="o-message__content">
 			{{#ifSome contentTitle contentDetail}}


### PR DESCRIPTION
The latest o-message will lazily construct a message if the parentElement is specified - even if there is already an element declared. This lead to the message being constructed inside the already defined message. As such:

![Screenshot 2020-10-05 at 14 51 33](https://user-images.githubusercontent.com/6599523/95088108-6fbaf680-071a-11eb-9d8f-96859851ea62.png)

`o-message` code:

```
if (this.opts.parentElement || !(this.messageElement instanceof HTMLElement)) {
			this.messageElement = construct.message(this.opts);
			// attach oMessage to specified parentElement or default to document body
			const element = this.opts.parentElement ? document.querySelector(this.opts.parentElement) : document.body;
			element.appendChild(this.messageElement);
		}
```

This updates the code to only specify `parentElement` if the message is lazy loaded.

Fix:

![Screenshot 2020-10-05 at 14 54 34](https://user-images.githubusercontent.com/6599523/95088355-bdcffa00-071a-11eb-9ce1-3fb2f32c0987.png)
