### PR TITLE
ACC-654 Update URL pointing to Billing Details

### DIFF
--- a/server/templates/partials/top/payment-failure.html
+++ b/server/templates/partials/top/payment-failure.html
@@ -3,7 +3,7 @@
 	contentTitle='Your payment has failed!'
 	contentDetail='Please update your payment details to continue your FT subscription.'
 	buttonLabel='Update now'
-	buttonUrl='https://myaccount.ft.com/payment/view'
+	buttonUrl='https://ft.com/myaccount/billing-details'
 	linkLabel='Help centre'
 	linkUrl='https://help.ft.com/help/contact-us/'
 	closeButton=false


### PR DESCRIPTION
With the new MMA and retirement of the old route, links that point to the old route need to be updated. This is one of them. 