### PR TITLE
[ACQ-605] Replace invalid XS breakpint with S

### DIFF
--- a/client/components/top/try-full-access/main.scss
+++ b/client/components/top/try-full-access/main.scss
@@ -57,7 +57,7 @@
 		.o-message__content-detail {
 			color: oColorsByName('white');
 
-			@include oGridRespondTo(XS) {
+			@include oGridRespondTo(S) {
 				margin-left: 52px;
 			}
 			@include oGridRespondTo(S) {
@@ -81,7 +81,7 @@
 
 			// not using oSpacingByName below so the second line is aligned with
 			// a letter on the top line
-			@include oGridRespondTo(XS) {
+			@include oGridRespondTo(S) {
 				margin-left: 52px;
 			}
 


### PR DESCRIPTION
According to https://github.com/Financial-Times/o-grid/blob/master/src/scss/_variables.scss#L51 `XS` breakpoint doesn't exist and is causing the build of `next-front-page` to fail