### PR TITLE
ug-308/add us-election-poll-tracker to messageSlotTop

### DIFF
--- a/client/components/top/us-election-poll-tracker/main.scss
+++ b/client/components/top/us-election-poll-tracker/main.scss
@@ -1,0 +1,51 @@
+.n-messaging-client-alert-banner--marketing__us-election {
+	display: flex;
+	flex-direction: column;
+
+	@include oGridRespondTo('M') {
+		flex-direction: row;
+	}
+
+	.o-message--alert {
+		padding: 0;
+	}
+
+	.o-message__content {
+		align-items: center;
+		flex-direction: column;
+		justify-content: space-around;
+		margin-left: -20px;
+
+		@include oGridRespondTo(M) {
+			flex-direction: row;
+			align-items: center;
+			height: 60px;
+			margin-left: 0;
+		}
+	}
+
+	.o-message__content-main {
+		font-size: 16px;
+		line-height: 20px;
+		@include oGridRespondTo(M) {
+			@include oTypographyDisplay($scale: 2, $include-font-family: false);
+		}
+	}
+
+	.o-message__actions--clickarea {
+		cursor: pointer;
+	}
+
+	&--gradient {
+		background: linear-gradient(to right, #082A4D, #CC0000);
+		color: oColorsByName('white');
+
+		.o-message__actions__primary {
+			@include oButtonsContent($opts: (
+				'type': 'primary',
+				'theme': 'inverse'
+			), $include-base-styles: false);
+			margin-right: 0;
+		}
+	}
+}

--- a/main.scss
+++ b/main.scss
@@ -8,3 +8,4 @@ $system-code: 'n-messaging-client';
 @import './client/components/bottom/marketing-popup-prompt/main';
 @import './client/components/bottom/remaining-articles/main';
 @import './client/components/top/try-full-access/main';
+@import './client/components/top/us-election-poll-tracker/main';

--- a/manifest.js
+++ b/manifest.js
@@ -78,5 +78,8 @@ module.exports = {
 		path: 'top/lazy',
 		lazy: true,
 		guruQueryString: 'offerId=41218b9e-c8ae-c934-43ad-71b13fcb4465',
+	},
+	usElectionPollTracker: {
+		path: 'top/us-election-poll-tracker'
 	}
 };

--- a/server/templates/partials/top/us-election-poll-tracker.html
+++ b/server/templates/partials/top/us-election-poll-tracker.html
@@ -1,0 +1,8 @@
+{{> n-messaging-client/server/templates/components/o-message
+	theme='marketing__us-election'
+	contentTitle='Trump vs Biden: get updated on who\'s ahead in the latest 2020 election polls'
+	buttonUrl='https://ig.ft.com/us-election-2020/'
+	buttonLabel='See the Poll Tracker'
+	closeButton=false
+	customClass='n-messaging-client-alert-banner--marketing__us-election--gradient'
+}}


### PR DESCRIPTION
To test locally, run `make install` then `make demo-watch`.
Go to https://toggler.ft.com/#messageSlotTop and select the `us-election-poll-tracker` variant.

This PR adds a top slot promotion for the US Poll Tracker

### Screenshots

| Mobile | Desktop |
| ------ | ----- |
|![image](https://user-images.githubusercontent.com/25018001/96700320-383d8280-1387-11eb-848a-d3d59c2c5d68.png)|![image](https://user-images.githubusercontent.com/25018001/96700356-4390ae00-1387-11eb-821a-50a5946453f3.png)|

[ticket](https://financialtimes.atlassian.net/secure/RapidBoard.jspa?rapidView=1128&projectKey=UG&modal=detail&selectedIssue=UG-308)
