### PR TITLE
Improve election week discount banners

### DIFF
--- a/client/components/top/us-election-week-discount/main.scss
+++ b/client/components/top/us-election-week-discount/main.scss
@@ -4,11 +4,13 @@ $smallScreenBannerWidth: 375px;
 .o-message--us-election-2020-discount-promo {
 
 	background-color: oColorsByName('slate');
-	width: 375px;
-	margin: auto;
 
-	@include oGridRespondTo(M) {
-		width: unset;
+	.o-message__container {
+		max-width: 375px;
+		margin: 0 auto;
+		@include oGridRespondTo(M) {
+			width: 100%;
+		}
 	}
 
 	.o-message__content {
@@ -28,7 +30,7 @@ $smallScreenBannerWidth: 375px;
 	}
 
 	.o-message__content-main {
-		align-self: center;
+		align-self: flex-start;
 		color: oColorsByName('white');
 		font-size: 22px;
 		line-height: 17px;


### PR DESCRIPTION
## Summary
- Improve the styles so the background is end to end on smaller resolutions
- Use `max-width` instead of `width` for the main part of the banner

## Screenshots
### Good looking
![image](https://user-images.githubusercontent.com/1168275/97462508-79193680-1947-11eb-8311-33bf2b9ca6f0.png)
![image](https://user-images.githubusercontent.com/1168275/97462542-833b3500-1947-11eb-957a-ea3485e9385f.png)
![image](https://user-images.githubusercontent.com/1168275/97462571-8afad980-1947-11eb-859e-db1792e747b7.png)
![image](https://user-images.githubusercontent.com/1168275/97462632-9b12b900-1947-11eb-88fd-b72bdef41a88.png)
![image](https://user-images.githubusercontent.com/1168275/97462704-abc32f00-1947-11eb-881b-5881e669eddd.png)
![image](https://user-images.githubusercontent.com/1168275/97462735-b54c9700-1947-11eb-81f8-dbfc6dcefb68.png)
![image](https://user-images.githubusercontent.com/1168275/97462761-be3d6880-1947-11eb-8769-9e942a2d45b1.png)
![image](https://user-images.githubusercontent.com/1168275/97462834-d01f0b80-1947-11eb-8de2-4f092a3aedec.png)
![image](https://user-images.githubusercontent.com/1168275/97462864-d6ad8300-1947-11eb-89e9-a2a38f45cabe.png)
![image](https://user-images.githubusercontent.com/1168275/97462891-de6d2780-1947-11eb-87e3-67077108a62a.png)
![image](https://user-images.githubusercontent.com/1168275/97462924-e6c56280-1947-11eb-9b7f-ebf723f1852f.png)
![image](https://user-images.githubusercontent.com/1168275/97462966-ef1d9d80-1947-11eb-8975-82dc63b014cb.png)
![image](https://user-images.githubusercontent.com/1168275/97462995-f775d880-1947-11eb-9ba0-79bb35d5de52.png)

#### Not so good looking:
![image](https://user-images.githubusercontent.com/1168275/97463041-0492c780-1948-11eb-9127-6dc923f6e67c.png)
![image](https://user-images.githubusercontent.com/1168275/97463242-32780c00-1948-11eb-97fb-56424e5ea48a.png)

This is the result of really narrow displays which adds a horizontal scroll...