### PR TITLE
ACQ-655 Align large banner vertically

### DIFF
--- a/client/components/top/us-election-week-discount/main.scss
+++ b/client/components/top/us-election-week-discount/main.scss
@@ -8,9 +8,6 @@ $smallScreenBannerWidth: 375px;
 	.o-message__container {
 		max-width: 375px;
 		margin: 0 auto;
-		@include oGridRespondTo(M) {
-			width: 100%;
-		}
 	}
 
 	.o-message__content {
@@ -37,6 +34,7 @@ $smallScreenBannerWidth: 375px;
 		white-space: nowrap;
 
 		@include oGridRespondTo(M) {
+			align-self: center;
 			font-size: 40px;
 			line-height: 31px;
 		}


### PR DESCRIPTION
https://financialtimes.atlassian.net/browse/ACQ-655

The large banner is now vertically centered
Before:
![Screenshot 2020-11-02 at 11 08 07](https://user-images.githubusercontent.com/14136353/97861600-edfbc000-1cfb-11eb-9b34-d367d026d6b7.png)


After:
![Screenshot 2020-11-02 at 11 08 59](https://user-images.githubusercontent.com/14136353/97861614-f3f1a100-1cfb-11eb-829a-565b440ebab6.png)

