### PR TITLE
[ACQ-433] Add border-bottom: 1px solid paper to slate top messages

### DIFF
--- a/client/components/top/three-months-intro-price-promo/main.scss
+++ b/client/components/top/three-months-intro-price-promo/main.scss
@@ -1,5 +1,6 @@
 $wheatLikeColor: #FCD8B5; // no analogy in Origami
 .o-message--three-months-intro-price-promo {
+	border-bottom: 1px solid oColorsByName('paper');
 	background-color: oColorsByName('slate');
 
 	.o-message__container {

--- a/client/components/top/try-full-access/main.scss
+++ b/client/components/top/try-full-access/main.scss
@@ -8,6 +8,7 @@
 .o-message--try-full-access {
 	display: flex;
 	flex-direction: column;
+	border-bottom: 1px solid oColorsByName('wheat');
 
 	@include oGridRespondTo(M) {
 		flex-direction: row;


### PR DESCRIPTION
Applies for `TryFullAccess` and `ThreeMonthsIntroPricePromo` banners.

### Before
![image](https://user-images.githubusercontent.com/1168275/98374937-14965f80-204a-11eb-9cb7-365991059198.png)

### After
![image](https://user-images.githubusercontent.com/1168275/98374915-0c3e2480-204a-11eb-84df-6207d2e05461.png)
