### PR TITLE
Fix navigation on new Manage Cookies page

### DIFF
--- a/server/templates/partials/bottom/cookie-consent.html
+++ b/server/templates/partials/bottom/cookie-consent.html
@@ -40,7 +40,7 @@
 					</a>
 				</div>
 				<div class="o-cookie-message__action o-cookie-message__action--secondary">
-					<a href="https://cookies.ft.com/preferences/manage-cookies" class="o-cookie-message__link" data-o-banner-action data-o-banner-action-type="manage">Manage cookies</a>
+					<a href="https://www.ft.com/preferences/manage-cookies" class="o-cookie-message__link" data-o-banner-action data-o-banner-action-type="manage">Manage cookies</a>
 				</div>
 			</div>
 


### PR DESCRIPTION
## Context

This week we launched the new Manage Cookies page. Among the changes it brought 
was the inclusion of the main header and footer (previously only a plain logo 
was rendered on non-whitelabel pages).

In production it transpired that because the "manage cookies" link in the cookie 
banner points to https://**cookies**.ft.com/preferences/manage-cookies,
all navigation links were broken (because the URLs are relative).

See https://financialtimes.atlassian.net/browse/NOPS-634

(The old app side-stepped this issue by rendering an inert logo instead of the 
main navigation and omitting the footer entirely, which has been our stop-gap 
fix too)

## What this PR does

Changing the subdomain to 'www' when linking to 
`https://www.ft.com/preferences/manage-cookies` will allow us to render the 
standard header and footer and offer a richer user experience.

## Additional considerations

We don't expect any other users to be affected by this change