### PR TITLE
CON-460 Add Climate Capital Feedback Message

### DIFF
--- a/critical.scss
+++ b/critical.scss
@@ -25,8 +25,8 @@ $o-tooltip-is-silent : false;
 ));
 @include oBanner();
 @include oMessage($opts: (
-	'types': ('alert'),
-	'states': ('success', 'neutral', 'error'),
+	'types': ('alert', 'notice'),
+	'states': ('success', 'neutral', 'error', 'feedback'),
 	'layout': ('default', 'inner')
 ));
 @include oCookieMessage($opts: (

--- a/manifest.js
+++ b/manifest.js
@@ -84,5 +84,9 @@ module.exports = {
 	},
 	threeMonthsIntroPricePromo: {
 		path: 'top/three-months-intro-price-promo',
+	},
+	climateCapitalFeedback: {
+		path: 'top/lazy',
+		lazy: true,
 	}
 };


### PR DESCRIPTION
We'd like to add a new message to the top of the [Climate Capital page](https://ft.com/climate-capital) to capture user feedback. The message is generated by `next-messaging-guru` (details [are in this PR](https://github.com/Financial-Times/next-messaging-guru/pull/124)), but a couple of minor tweaks are required here to add support for the 'notice' `o-message` type and to add the new message to the manifest.

Design specs for the message [are in this ticket](https://financialtimes.atlassian.net/browse/CON-408).
Content specs [are in this ticket](https://financialtimes.atlassian.net/secure/RapidBoard.jspa?rapidView=1211&modal=detail&selectedIssue=CON-460).