### PR TITLE
Update `o-cookie-message`

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -44,6 +44,6 @@
     "n-myft-ui": "^22.0.0",
     "n-swg": "^2.1.1",
     "o-grid": "^5.2.6",
-    "o-cookie-message": "^5.0.9"
+    "o-cookie-message": "^5.1.2"
   }
 }

--- a/server/templates/partials/bottom/cookie-consent.html
+++ b/server/templates/partials/bottom/cookie-consent.html
@@ -40,7 +40,7 @@
 					</a>
 				</div>
 				<div class="o-cookie-message__action o-cookie-message__action--secondary">
-					<a href="https://www.ft.com/preferences/manage-cookies" class="o-cookie-message__link" data-o-banner-action data-o-banner-action-type="manage">Manage cookies</a>
+					<a href="/preferences/manage-cookies{{#if @root.realPath}}?redirect={{@root.realPath}}{{/if}}" class="o-cookie-message__link" data-o-banner-action data-o-banner-action-type="manage">Manage cookies</a>
 				</div>
 			</div>
 


### PR DESCRIPTION
This PR 

1. Pulls in a version of o-cookie-message that responds to backward navigation swipes and correctly displays / hides the Cookie Banner even when the page is reloaded from the [bfcache](https://web.dev/bfcache/)
1. Uses a relative link makes it easier to test user journeys locally
1. restores the redirect query parameter mentioned in [this discussion](https://github.com/Financial-Times/o-cookie-message/pull/145#discussion_r567738218) allowing users to navigate back to the page on which they were shown the cookie banner