### PR TITLE
Make manage cookies link more flexible and informative

### DIFF
--- a/server/templates/partials/bottom/cookie-consent.html
+++ b/server/templates/partials/bottom/cookie-consent.html
@@ -40,7 +40,7 @@
 					</a>
 				</div>
 				<div class="o-cookie-message__action o-cookie-message__action--secondary">
-					<a href="https://www.ft.com/preferences/manage-cookies" class="o-cookie-message__link" data-o-banner-action data-o-banner-action-type="manage">Manage cookies</a>
+					<a href="/preferences/manage-cookies{{#if @root.realPath}}?redirect={{@root.realPath}}{{/if}}" class="o-cookie-message__link" data-o-banner-action data-o-banner-action-type="manage">Manage cookies</a>
 				</div>
 			</div>
 


### PR DESCRIPTION
This PR makes two changes:
1. Using a relative link makes it easier to test user journeys locally
2. It restores the `redirect` query parameter mentioned in [this discussion](Financial-Times/o-cookie-message#145 (comment)) allowing users to navigate back to the page on which they were shown the cookie banner