### PR TITLE
fix: revert order to invoke customSetup module

### DIFF
--- a/client/bottom-slot.js
+++ b/client/bottom-slot.js
@@ -44,7 +44,7 @@ module.exports = function ({ config={}, guruResult, customSetup }={}) {
 	if (!customSetup) {
 		banner.open();
 	} else {
-		customSetup = customSetup || customSetup.default; // ESM modules
+		customSetup = customSetup.default || customSetup; // ESM modules
 		function customSetupCallback ({ skip = false } = {}) {
 			if (skip) {
 				trackEventAction('skip');


### PR DESCRIPTION
Rervert change done [here](https://github.com/Financial-Times/n-messaging-client/blob/aa2e6c3d0ef918f9e1cead52ef485dcfb3478b6e/client/bottom-slot.js#L47) in this [commit](https://github.com/Financial-Times/n-messaging-client/commit/aa2e6c3d0ef918f9e1cead52ef485dcfb3478b6e#) following the pattern used [here](https://github.com/Financial-Times/n-messaging-client/blob/aa2e6c3d0ef918f9e1cead52ef485dcfb3478b6e/client/bottom-slot.js#L2) since it cause an error for the latest releases in particular for `next-front-page`

Thread related https://financialtimes.slack.com/archives/C042NBBTM/p1619712159264900