### PR TITLE
bumped circle cache keys to version 3 to clear cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,13 +22,13 @@ references:
 
   npm_cache_keys: &npm_cache_keys
     keys:
-        - v2-dependency-npm-{{ checksum "package.json" }}-
-        - v2-dependency-npm-{{ checksum "package.json" }}
-        - v2-dependency-npm-
+        - v3-dependency-npm-{{ checksum "package.json" }}-
+        - v3-dependency-npm-{{ checksum "package.json" }}
+        - v3-dependency-npm-
 
   cache_npm_cache: &cache_npm_cache
     save_cache:
-        key: v2-dependency-npm-{{ checksum "package.json" }}-{{ epoch }}
+        key: v3-dependency-npm-{{ checksum "package.json" }}-{{ epoch }}
         paths:
         - ./node_modules/
 


### PR DESCRIPTION
This is a pull request to clear the Circle CI cache as the nightly builds were failing to install some dependencies.