### PR TITLE
changes cache keys to be branch-specific

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,13 +22,13 @@ references:
 
   npm_cache_keys: &npm_cache_keys
     keys:
-        - v3-dependency-npm-{{ checksum "package.json" }}-
-        - v3-dependency-npm-{{ checksum "package.json" }}
-        - v3-dependency-npm-
+        - cache-v4-{{ .Branch }}-{{ checksum "package.json" }}-
+        - cache-v4-{{ .Branch }}-{{ checksum "package.json" }}
+        - cache-v4-
 
   cache_npm_cache: &cache_npm_cache
     save_cache:
-        key: v3-dependency-npm-{{ checksum "package.json" }}-{{ epoch }}
+        key: cache-v4-{{ .Branch }}-{{ checksum "package.json" }}
         paths:
         - ./node_modules/
 


### PR DESCRIPTION
currently the npm cache is for all branches. Nightly builds are broken after trying to use the cache saved by renovate-circleci-node-15.x. This PR is to split out the cache on a per branch basis.