### PR TITLE
ACC-1003 Add Top Banner for Single Term Renew message

### DIFF
--- a/manifest.js
+++ b/manifest.js
@@ -30,6 +30,9 @@ module.exports = {
 	paymentFailure: {
 		path: 'top/payment-failure'
 	},
+	singleTermRenew: {
+		path: 'top/renew-single-term-banner'
+	},
 	anonSubscribeNow: {
 		path: 'top/anon-subscribe-now',
 		trackingContext: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9354,9 +9354,9 @@
       }
     },
     "n-myft-ui": {
-      "version": "npm:@financial-times/n-myft-ui@23.0.1",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-myft-ui/-/n-myft-ui-23.0.1.tgz",
-      "integrity": "sha512-u0g/lAH2jtHD2osB6pXxrQ0tuC4od/lwvtdielS4P6dVJokQAPhkwH8vtqB9cKPHzQBQ+3620hzwFonMf7obrw=="
+      "version": "npm:@financial-times/n-myft-ui@23.1.3",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-myft-ui/-/n-myft-ui-23.1.3.tgz",
+      "integrity": "sha512-UqEWirIPVtKtG0dXf3SsYq1zTJO9HbfiMQngeYyoV0xIAaWbbCMPXgHUpdZdfm35kFonvV6xyUY90bcPm8HaAA=="
     },
     "n-swg": {
       "version": "npm:@financial-times/n-swg@2.1.1",

--- a/server/templates/partials/top/renew-single-term-banner.html
+++ b/server/templates/partials/top/renew-single-term-banner.html
@@ -1,0 +1,9 @@
+{{> n-messaging-client/server/templates/components/o-message
+	theme='error'
+	contentTitle='Your subscription has expired.'
+	contentDetail='Please renew your FT subscription.'
+	buttonLabel='Renew'
+	buttonUrl='https://www.ft.com/manage/subscription/renew'
+	closeButton=false
+	renderOpen=true
+}}


### PR DESCRIPTION
# Description
Single Term users are user who are not on a subscription that auto renews. What this means, their subscription can expire. We want to encourage them to renew their subscription when that happens so we are adding a Top banner to FT pages. 

# Ticket
https://financialtimes.atlassian.net/browse/ACC-1003

# Screenshot in n-messaging-client demo
Yes, it looks a bit weird, but unless we release this and the changes in Ammit, this is the best I have for a screenshot
![Screenshot 2021-08-23 at 14 26 35](https://user-images.githubusercontent.com/31079643/130458664-e8f1c10d-bbd6-4730-97e1-e3e7ac3882b3.png)

# ... but I edited the NonPayment Banner to show the Renew Banner content, and they use the same component, so the Renew Banner should looks like so
**oops, the button should say Renew, but you get the idea**
![Screenshot 2021-08-23 at 14 53 10](https://user-images.githubusercontent.com/31079643/130459523-e1bbd851-0d20-47f5-b5e1-8a06648752dd.png)
![Screenshot 2021-08-23 at 14 53 25](https://user-images.githubusercontent.com/31079643/130459532-cdac0c52-9ffd-44d7-b3ce-4cd597e9b3ce.png)
