### PR TITLE
UG-507: Show customer care message on activationNotStarted, activationNotComplete and activationSkipped variants

### DIFF
--- a/manifest.js
+++ b/manifest.js
@@ -79,13 +79,13 @@ module.exports = {
 		lazy: true
 	},
 	activationNotStarted: {
-		path: 'bottom/activation-not-started'
+		path: 'bottom/customer-care'
 	},
 	activationNotComplete: {
-		path: 'bottom/activation-not-complete'
+		path: 'bottom/customer-care'
 	},
 	activationSkipped: {
-		path: 'bottom/activation-skipped'
+		path: 'bottom/customer-care'
 	},
 	aberdeenStandardLifeCancellation: {
 		path: 'bottom/asi-cancellation'

--- a/server/templates/partials/bottom/customer-care.html
+++ b/server/templates/partials/bottom/customer-care.html
@@ -1,0 +1,21 @@
+<div class="n-messaging-client-messaging-banner n-messaging-client-messaging-banner--customer-care">
+	{{#> n-messaging-client/server/templates/components/o-banner
+		renderOpen=true
+		small=true
+		themeProduct=true
+	}}
+		<div class="o-banner__inner" data-o-banner-inner>
+			<div class="o-banner__content">
+				<header class="o-banner__heading">
+				<h1>Finding everything you need?</h1>
+				</header>
+				<p>Find the most relevant content to you and personalise your alerts with a complimentary call to guide you through FT.com & the FT App</p>
+			</div>
+			<div class="o-banner__actions">
+				<div class="o-banner__action">
+				<a href="https://financialtimes.10to8.com/" class="o-banner__button">Book now</a>
+				</div>
+			</div>
+		</div>
+	{{/n-messaging-client/server/templates/components/o-banner}}
+</div>


### PR DESCRIPTION
### Description
Added new template `customer-care` for bottom slot messages and assigned it to the `activationNotStarted`, `activationNotComplete` and `activationSkipped` variants replacing the current messages.

### Ticket
https://financialtimes.atlassian.net/browse/UG-507