### PR TITLE
CON-1641 bring v10 templates

### DIFF
--- a/client/components/top/disrupted-world/main.scss
+++ b/client/components/top/disrupted-world/main.scss
@@ -1,0 +1,94 @@
+.o-message--disrupted-world {
+	border-bottom: 1px solid oColorsByName('white');
+	background-color: oColorsByName('teal');
+
+	.o-message__container {
+		display: flex;
+		padding: oSpacingByName('s4');
+
+		.o-message__content {
+			color: oColorsByName('white');
+			display: flex;
+			flex-direction: column;
+			margin: 0 auto;
+			padding: 0;
+
+			@include oGridRespondTo($from: M) {
+				width: 780px;
+				flex-direction: row;
+				justify-content: space-between;
+				align-items: center;
+				padding: oSpacingByName('s4');
+			}
+
+			@include oGridRespondTo($from: L) {
+				min-width: 780px;
+				width: auto;
+			}
+
+			.o-message__content-main {
+				margin-left: 0;
+
+				@include oTypographySans($scale: 0);
+
+				.o-message__content-highlight {
+					color: oColorsByName('white');
+					@include oTypographySans($scale: 2);
+
+					@include oGridRespondTo($from: M) {
+						@include oTypographySans($scale: 3);
+					}
+				}
+
+				@include oGridRespondTo($from: M) {
+					margin-bottom: 0;
+					@include oTypographySans($scale: 3);
+				}
+
+				.o-message__content-detail {
+					display: block;
+
+					@include oTypographySans($scale: 0);
+
+					@include oGridRespondTo($from: S) {
+						@include oTypographySans($scale: 1);
+					}
+
+					@include oGridRespondTo($from: M) {
+						@include oTypographySans($scale: 2);
+					}
+				}
+			}
+		}
+	}
+
+	.o-message__actions {
+		padding-bottom: 0;
+		margin-left: 0;
+		margin-bottom: oSpacingByName('s1');
+
+		@include oGridRespondTo($from: M) {
+			padding: 0;
+			margin-bottom: 0;
+			margin-left: oSpacingByName('s4');;
+		}
+	}
+
+	.o-message__actions__primary {
+		padding: oSpacingByName('s2') oSpacingByName('s6');
+		background-color: oColorsByName('white');
+		color: oColorsByName('teal');
+		border-color: transparent;
+		width: 170px;
+
+		&:hover {
+			background-color: oColorsByName('white');
+		}
+
+		@include oGridRespondTo($from: M) {
+			width: 180px;
+
+			@include oTypographySans($scale: 0);
+		}
+	}
+}

--- a/main.scss
+++ b/main.scss
@@ -14,3 +14,4 @@ $system-code: "n-messaging-client";
 @import "./client/components/top/cop-open-day-climate-capital-anon/main";
 @import "./client/components/top/jan-22-digital-sale-banner/main";
 @import "./client/components/bottom/jan-22-digital-sale-slider/main";
+@import "./client/components/top/disrupted-world/main"

--- a/manifest.js
+++ b/manifest.js
@@ -105,4 +105,10 @@ module.exports = {
 			opportunity_type: 'jan22DigitalSaleSlider',
 		}
 	},
+	disruptedWorld: {
+		path: 'top/disrupted-world',
+		trackingContext: {
+			opportunity_type: 'disruptedWorld',
+		}
+	},
 };

--- a/secret-squirrel.cjs
+++ b/secret-squirrel.cjs
@@ -16,6 +16,7 @@ module.exports = {
 			'19dc305c\\x2dd9dd\\x2d22c6\\x2d6c05\\x2d6dbd76417fd7', // server/templates/partials/bottom/jan-22-digital-sale-slider.html:28
 			'5f60b8b4\\x2dcbf0\\x2d18d7\\x2ddf41\\x2d9caa1171e8c1', // server/templates/partials/top/anon-subscribe-now.html:5|18
 			'0b1f847b\\x2d03f4\\x2d87d5\\x2d1f1d\\x2def958102d37c', // server/templates/partials/top/cop-open-day-climate-capital-anon.html:5
+			'61895f85\\x2db88c\\x2dba04\\x2d7a0a\\x2db3ca54c20651', // server/templates/partials/top/disrupted-world.html:5
 			'54c9ee8b\\x2d08b5\\x2d3a4f\\x2d0dbd\\x2db0d60b121d2e', // server/templates/partials/top/jan-22-digital-sale-banner.html:5
 			'a44c9005\\x2d2a9c\\x2dfe2a\\x2d9140\\x2d1311ff87f25f' // server/templates/partials/top/print-banner-usa.html:4
 		]

--- a/server/templates/partials/top/disrupted-world.html
+++ b/server/templates/partials/top/disrupted-world.html
@@ -1,6 +1,6 @@
 {{> n-messaging-client/server/templates/components/o-message
 	theme='disrupted-world'
-	contentTitle='Your Guide to a Disrupted World'
+	contentTitle='Your guide to a disrupted world'
 	contentDetail=''
 	buttonUrl='https://subs.ft.com/sd33_ddd?segmentid=61895f85-b88c-ba04-7a0a-b3ca54c20651'
 	buttonLabel='Subscribe'

--- a/server/templates/partials/top/disrupted-world.html
+++ b/server/templates/partials/top/disrupted-world.html
@@ -1,0 +1,8 @@
+{{> n-messaging-client/server/templates/components/o-message
+	theme='disrupted-world'
+	contentTitle='Your Guide to a Disrupted World'
+	contentDetail=''
+	buttonUrl='https://subs.ft.com/sd33_ddd?segmentid=61895f85-b88c-ba04-7a0a-b3ca54c20651'
+	buttonLabel='Subscribe'
+	closeButton=false
+}}


### PR DESCRIPTION
# Description

This is a branch from the previous v9 version. We are doing this because v10 uses `n-myft-ui@25` and v9 uses `n-myft-ui@23`, and to solve a CI issue with `next-stream-page` we need to use temporally the v23 (you can see more details about this issue [here](https://github.com/Financial-Times/next-stream-page/pull/2819)).

 We are cherry-picking  the commits of this [PR](https://github.com/Financial-Times/n-messaging-client/pull/429) that was released in version 10.1.0