### PR TITLE
add npm-publish-token context to circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,46 +3,54 @@
 
 references:
 
-  container_config_node12: &container_config_node12
+  container_config_node12:
+    &container_config_node12
     working_directory: ~/project/build
     docker:
       - image: cimg/node:12.22-browsers
 
-  workspace_root: &workspace_root
-    ~/project
+  workspace_root: &workspace_root ~/project
 
-  attach_workspace: &attach_workspace
+  attach_workspace:
+    &attach_workspace
     attach_workspace:
       at: *workspace_root
 
-  npm_cache_keys: &npm_cache_keys
+  npm_cache_keys:
+    &npm_cache_keys
     keys:
-        - cache-v6-{{ .Branch }}-{{ checksum "package.json" }}-
-        - cache-v6-{{ .Branch }}-{{ checksum "package.json" }}
+      - cache-v6-{{ .Branch }}-{{ checksum "package.json" }}-
+      - cache-v6-{{ .Branch }}-{{ checksum "package.json" }}
 
-  cache_npm_cache: &cache_npm_cache
+  cache_npm_cache:
+    &cache_npm_cache
     save_cache:
-        key: cache-v6-{{ .Branch }}-{{ checksum "package.json" }}
-        paths:
-          - ./node_modules/
+      key: cache-v6-{{ .Branch }}-{{ checksum "package.json" }}
+      paths:
+        - ./node_modules/
 
-  restore_npm_cache: &restore_npm_cache
+  restore_npm_cache:
+    &restore_npm_cache
     restore_cache:
-        <<: *npm_cache_keys
+      <<: *npm_cache_keys
 
-  filters_only_main: &filters_only_main
+  filters_only_main:
+    &filters_only_main
     branches:
       only: main
 
-  filters_ignore_main: &filters_ignore_main
+  filters_ignore_main:
+    &filters_ignore_main
     branches:
       ignore: main
 
-  filters_ignore_tags: &filters_ignore_tags
+  filters_ignore_tags:
+    &filters_ignore_tags
     tags:
       ignore: /.*/
 
-  filters_version_tag: &filters_version_tag
+  filters_version_tag:
+    &filters_version_tag
     tags:
       only:
         - /^v?\d+\.\d+\.\d+(?:-beta\.\d+)?$/
@@ -62,7 +70,9 @@ jobs:
       - checkout
       - run:
           name: Checkout next-ci-shared-helpers
-          command: git clone --depth 1 git@github.com:Financial-Times/next-ci-shared-helpers.git .circleci/shared-helpers
+          command: git clone --depth 1
+            git@github.com:Financial-Times/next-ci-shared-helpers.git
+            .circleci/shared-helpers
       - *restore_npm_cache
       - node/install-npm:
           version: "7"
@@ -105,7 +115,8 @@ jobs:
       - run:
           name: shared-helper / npm-store-auth-token
           command: .circleci/shared-helpers/helper-npm-store-auth-token
-      - run: npx snyk monitor --org=customer-products --project-name=Financial-Times/n-messaging-client
+      - run: npx snyk monitor --org=customer-products
+          --project-name=Financial-Times/n-messaging-client
       - run:
           name: shared-helper / npm-version-and-publish-public
           command: .circleci/shared-helpers/helper-npm-version-and-publish-public
@@ -134,6 +145,7 @@ workflows:
           requires:
             - build
       - publish:
+          context: npm-publish-token
           filters:
             <<: *filters_version_tag
           requires:


### PR DESCRIPTION
We need teams to migrate their CircleCI pipelines to use the newly created "npm-publish-token" context, so that we can revoke all of the old untrusted tokens.
