### PR TITLE
UG-842: Remove dangling tag from embeddedOnboarding template

### DIFF
--- a/server/templates/partials/bottom/embedded-onboarding.html
+++ b/server/templates/partials/bottom/embedded-onboarding.html
@@ -9,7 +9,6 @@
 					<iframe src="https://ft.com/activate/embedded/bundles" frameborder="0" width="100%" height="100%" id="onboarding-iframe" tabindex="0" aria-label="Get started with the F T"></iframe>
 				</div>
 			</div>
-			<div class="o-banner__actions">
 		</div>
 	{{/n-messaging-client/server/templates/components/o-banner}}
 </div>


### PR DESCRIPTION
### Description

Removes an unclosed div tag on the message template that was breaking the layout of the message's consumer.
