### PR TITLE
ACC1627 - fix typo Danske Bank message

### DIFF
--- a/server/templates/partials/bottom/content-message-danske-bank.html
+++ b/server/templates/partials/bottom/content-message-danske-bank.html
@@ -2,7 +2,7 @@
 	{{#> n-messaging-client/server/templates/components/o-banner
 		themeCompact=true
 		renderOpen=true
-		closeLabel="Close the 4-week trial promotional banner"
+		closeLabel="Close the cancellation promotional banner"
 	}}
 	<div class="o-banner__inner" data-o-banner-inner="" data-o-banner-inner="">
 		<div class="o-banner__content">


### PR DESCRIPTION
fix a typo for accesibility purposes in the Danske Bank message.