### PR TITLE
myftclient to use npm replacing bower

### DIFF
--- a/client/components/top/myft-disengaged-tooltip/main.js
+++ b/client/components/top/myft-disengaged-tooltip/main.js
@@ -4,7 +4,7 @@
 // - who haven't seen the tooltip more than 3 times
 
 import Tooltip from '@financial-times/o-tooltip';
-import myftClient from 'next-myft-client/myft-bower';
+import myftClient from 'next-myft-client/myft-npm';
 import {broadcast} from 'n-ui-foundations';
 import Cookies from 'js-cookie';
 

--- a/client/components/top/myft-disengaged-tooltip/main.js
+++ b/client/components/top/myft-disengaged-tooltip/main.js
@@ -4,7 +4,7 @@
 // - who haven't seen the tooltip more than 3 times
 
 import Tooltip from '@financial-times/o-tooltip';
-import myftClient from 'next-myft-client/myft-npm';
+import myftClient from 'next-myft-client/myft-client';
 import {broadcast} from 'n-ui-foundations';
 import Cookies from 'js-cookie';
 


### PR DESCRIPTION
One of the components in myft-disengaged-tooltip had reference to 'next-myft-client/myft-bower'. 

With the removal of bower components, 'next-myft-client/myft-bower' is not compiled anymore.

Therefore, this file has been replaced to use 'next-myft-client/myft-npm

![Screenshot 2022-05-19 at 12 06 53](https://user-images.githubusercontent.com/9668520/169279589-b56bb1ac-1a1b-4e7f-bdf2-b3b28a1a71ed.png)
Figure 1: Compilation successful

<img width="637" alt="Screenshot 2022-05-19 at 12 07 37" src="https://user-images.githubusercontent.com/9668520/169279679-5890d18b-9270-488f-82d2-ee12c9f4ba44.png">
'
Figure 2: Output
