### PR TITLE
CPP-890 update config for nightly scheduled-pipelines

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,6 +130,11 @@ workflows:
   version: 2
 
   build-test:
+    when:
+      not:
+        equal:
+          - scheduled_pipeline
+          - << pipeline.trigger_source >>
     jobs:
       - build:
           filters:
@@ -147,6 +152,11 @@ workflows:
               node-version: [ "16.14", "14.19" ]
 
   build-test-publish:
+    when:
+      not:
+        equal:
+          - scheduled_pipeline
+          - << pipeline.trigger_source >>
     jobs:
       - build:
           filters:
@@ -172,11 +182,14 @@ workflows:
             - test-v16.14
 
   nightly:
-    triggers:
-      - schedule:
-          cron: "0 0 * * *"
-          filters:
-            <<: *filters_only_main
+    when:
+      and:
+        - equal:
+            - scheduled_pipeline
+            - << pipeline.trigger_source >>
+        - equal:
+            - nightly
+            - << pipeline.schedule.name >>
     jobs:
       - build:
           context: next-nightly-build


### PR DESCRIPTION
Applies workflows filtering to your circleci/config.yml, so that the nightly workflow runs with the scheduled trigger, and other workflows won't run with the scheduled trigger.