### PR TITLE
Make tweaks to academia cta message

### DIFF
--- a/client/components/bottom/academia-cta/main.js
+++ b/client/components/bottom/academia-cta/main.js
@@ -60,14 +60,13 @@ module.exports = (banner, done) => {
 		return done({ skip: true });
 	}
 
-	document.addEventListener( "click", handleClick, false );
+	document.addEventListener("click", handleClick, false);
 
-	function handleClick( event ) {
-
+	function handleClick(event) {
 		if (bannerElement.contains(event.target) === false) {
-			banner.close()
+			banner.close();
 		}
-	}	
+	}
 
 	if (navigator.clipboard && navigator.clipboard.writeText) {
 		bannerElement

--- a/client/components/bottom/academia-cta/main.js
+++ b/client/components/bottom/academia-cta/main.js
@@ -1,65 +1,79 @@
-const Message = require('@financial-times/o-message').default;
-const pageKitFlags = require('@financial-times/dotcom-ui-flags');
+const Message = require("@financial-times/o-message").default;
+const pageKitFlags = require("@financial-times/dotcom-ui-flags");
 
 let successMessages = new Map();
 
-const handleActionClickEvent = event => {
-	if (!event.target.classList.contains('o-banner__action')) {
+const handleActionClickEvent = (event) => {
+	if (!event.target.classList.contains("o-banner__action")) {
 		return;
 	}
 
 	event.preventDefault();
 
 	const target = event.target;
-	const urlSelectorElement = target.closest('.academia-cta-url-selector');
-	const anchorElement = urlSelectorElement.querySelector('.academia-cta-url-selector__url a');
+	const urlSelectorElement = target.closest(".academia-cta-url-selector");
+	const anchorElement = urlSelectorElement.querySelector(
+		".academia-cta-url-selector__url a"
+	);
 
 	// as there are two content elements (one for small screens, one for large)
 	// we need to identify which element the click originated from
 	// and generate a unique query selector to pass to o-message
-	const bannerContentElement = target.closest('.o-banner__content');
-	const bannerContentSelector = Array.from(bannerContentElement.classList.values()).reduce((prev, curr) => {
+	const bannerContentElement = target.closest(".o-banner__content");
+	const bannerContentSelector = Array.from(
+		bannerContentElement.classList.values()
+	).reduce((prev, curr) => {
 		return `${prev}.${curr}`;
-	}, '');
+	}, "");
 
-	navigator.clipboard.writeText(anchorElement.getAttribute('href'))
-		.then(() => {
-			urlSelectorElement.style.display = 'none';
+	navigator.clipboard.writeText(anchorElement.getAttribute("href")).then(() => {
+		urlSelectorElement.style.display = "none";
 
-			if (successMessages.has(bannerContentSelector)) {
-				successMessages.get(bannerContentSelector).open();
-			} else {
-				const msg = new Message(null, {
-					type: 'alert',
-					state: 'success',
-					content: {
-						detail: 'The link has been copied to the clipboard',
-					},
-					parentElement: `${bannerContentSelector} .academia-cta-message-container`,
-				});
+		if (successMessages.has(bannerContentSelector)) {
+			successMessages.get(bannerContentSelector).open();
+		} else {
+			const msg = new Message(null, {
+				type: "alert",
+				state: "success",
+				content: {
+					detail: "The link has been copied to the clipboard",
+				},
+				parentElement: `${bannerContentSelector} .academia-cta-message-container`,
+			});
 
-				msg.messageElement.addEventListener('o.messageClosed', () => {
-					urlSelectorElement.style.display = 'flex';
-				});
+			msg.messageElement.addEventListener("o.messageClosed", () => {
+				urlSelectorElement.style.display = "flex";
+			});
 
-				// store the message in a map for later retrieval
-				// as o-message has no method for deletion/removal
-				successMessages.set(bannerContentSelector, msg);
-			}
-		});
+			// store the message in a map for later retrieval
+			// as o-message has no method for deletion/removal
+			successMessages.set(bannerContentSelector, msg);
+		}
+	});
 };
 
 module.exports = (banner, done) => {
 	const flags = pageKitFlags.init();
 	const bannerElement = banner.bannerElement;
 
-	if (flags.get('academicCtaTest') !== 'variant') {
+	if (flags.get("academicCtaTest") !== "variant") {
 		return done({ skip: true });
 	}
 
+	document.addEventListener( "click", handleClick, false );
+
+	function handleClick( event ) {
+
+		if (bannerElement.contains(event.target) === false) {
+			banner.close()
+		}
+	}	
+
 	if (navigator.clipboard && navigator.clipboard.writeText) {
-		bannerElement.querySelectorAll('.o-banner__action').forEach(buttonElement => buttonElement.classList.remove('n-ui-hide'));
-		bannerElement.addEventListener('click', handleActionClickEvent);
+		bannerElement
+			.querySelectorAll(".o-banner__action")
+			.forEach((buttonElement) => buttonElement.classList.remove("n-ui-hide"));
+		bannerElement.addEventListener("click", handleActionClickEvent);
 	}
 
 	done();

--- a/client/components/bottom/academia-cta/main.scss
+++ b/client/components/bottom/academia-cta/main.scss
@@ -10,6 +10,13 @@
 	box-sizing: border-box;
 }
 
+[data-n-messaging-name="academiaCTA"] .o-banner__close {
+	position: absolute;
+	right: 24px;
+	top: 24px;
+
+}
+
 .academia-cta {
 	&-hero-image {
 		text-align: center;
@@ -21,18 +28,18 @@
 	}
 
 	&-heading h1 {
-		font-size: 24px;
+		font-size: 20px;
 		line-height: 1;
 		margin-bottom: 16px;
 		color: oColorsByName('slate');
 
 		@include oGridRespondTo(L) {
-			font-size: 28px;
+			font-size: 24px;
 		}
 	}
 
 	&-body-text {
-		font-size: 20px;
+		font-size: 18px;
 		line-height: 1.78;
 		color: oColorsByName('black-70');
 
@@ -41,11 +48,11 @@
 		}
 
 		@include oGridRespondTo(L) {
-			font-size: 28px;
+			font-size: 20px;
 			line-height: 1.14;
 
 			p {
-				margin-bottom: 32px;
+				margin-bottom: 10px;
 			}
 		}
 	}
@@ -55,14 +62,16 @@
 
 		&__text {
 			flex: 1;
-			padding-right: 86px;
+			padding-right: 60px;
 			min-width: 0;
+			max-width: 600px;
 		}
 	}
 
 	&-url-selector {
 		display: flex;
 		flex-wrap: wrap;
+		padding-top: 36px;
 
 		&__url {
 			display: flex;
@@ -91,6 +100,7 @@
 			text-overflow: ellipsis;
 			white-space: nowrap;
 			overflow: hidden;
+			font-size: 18px;
 		}
 	}
 }

--- a/client/components/bottom/academia-cta/main.scss
+++ b/client/components/bottom/academia-cta/main.scss
@@ -16,7 +16,7 @@
 	}
 
 	&-heading h1 {
-		font-size: 20px;
+		font-size: 24px;
 		line-height: 1;
 		margin-bottom: 16px;
 		color: oColorsByName('slate');
@@ -27,7 +27,7 @@
 	}
 
 	&-body-text {
-		font-size: 18px;
+		font-size: 20px;
 		line-height: 1.78;
 		color: oColorsByName('black-70');
 
@@ -59,7 +59,8 @@
 		flex-wrap: wrap;
 
 		&__url {
-			display: block;
+			display: flex;
+			align-items: center;
 			flex: 1;
 			box-sizing: border-box;
 			padding: 8px;

--- a/client/components/bottom/academia-cta/main.scss
+++ b/client/components/bottom/academia-cta/main.scss
@@ -5,6 +5,11 @@
 	background-color: oColorsByName('white-80');
 }
 
+[data-n-messaging-name="academiaCTA"] .o-banner__content {
+	width: 100%;
+	box-sizing: border-box;
+}
+
 .academia-cta {
 	&-hero-image {
 		text-align: center;
@@ -51,6 +56,7 @@
 		&__text {
 			flex: 1;
 			padding-right: 86px;
+			min-width: 0;
 		}
 	}
 


### PR DESCRIPTION
### Description
made design tweaks for the academiaCTA message.

- [x] Align the link text vertically in the box
- [x] Change font size of header to 24px
- [x] Change font size of the body copy to 20px
- [x] Make the image left-aligned, with 60px padding between text and image (desktop).
- [x] 24px top and right padding for the close icon (desktop and mobile).

### Screenshots

| Before | After |
| ------ | ----- |
| <img width="1440" alt="Screenshot 2022-06-23 at 15 51 33" src="https://user-images.githubusercontent.com/64967358/175331337-95dfe15d-b63b-4244-8d90-a0822facf6a4.png">|  <img width="1440" alt="Screenshot 2022-06-23 at 15 51 46" src="https://user-images.githubusercontent.com/64967358/175331706-21107d8c-3997-4535-9938-23d26b8591b4.png">     |

### Ticket
https://financialtimes.atlassian.net/browse/UG-911