### PR TITLE
ADSDEV-1231 fix on cookie banner release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
       "peerDependencies": {
         "@financial-times/n-myft-ui": "^28.0.6",
         "@financial-times/o-banner": "^4.4.2",
-        "@financial-times/o-cookie-message": "^6.3.1",
+        "@financial-times/o-cookie-message": "^6.5.0",
         "@financial-times/o-grid": "^6.1.5",
         "@financial-times/o-loading": "^5.2.1",
         "@financial-times/o-message": "^5.2.1",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   "peerDependencies": {
     "@financial-times/n-myft-ui": "^28.0.6",
     "@financial-times/o-banner": "^4.4.2",
-    "@financial-times/o-cookie-message": "^6.3.1",
+    "@financial-times/o-cookie-message": "^6.5.0",
     "@financial-times/o-grid": "^6.1.5",
     "@financial-times/o-loading": "^5.2.1",
     "@financial-times/o-message": "^5.2.1",


### PR DESCRIPTION
This PR is to fix an issue in [[ADSDEV] Cookie Banner fixes](https://github.com/Financial-Times/n-messaging-client/pull/474), which incorrectly bumped the version of `o-cookie-message` in devDependency rather than peerDependency.

JIRA ticket: https://financialtimes.atlassian.net/browse/ADSDEV-1231
Origami PR for `o-cookie-message`: https://github.com/Financial-Times/origami/pull/867