### PR TITLE
Update to Node 18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,58 +3,49 @@
 
 references:
 
-  container_config_node:
-    &container_config_node
+  container_config_node: &container_config_node
     working_directory: ~/project/build
     docker:
       - image: cimg/node:<< parameters.node-version >>-browsers
     parameters:
       node-version:
-        default: "16.14"
+        default: "18.16"
         type: string
 
   workspace_root: &workspace_root ~/project
 
-  attach_workspace:
-    &attach_workspace
+  attach_workspace: &attach_workspace
     attach_workspace:
       at: *workspace_root
 
-  npm_cache_keys:
-    &npm_cache_keys
+  npm_cache_keys: &npm_cache_keys
     keys:
       - cache-v6-{{ .Branch }}-{{ checksum "package.json" }}-
       - cache-v6-{{ .Branch }}-{{ checksum "package.json" }}
 
-  cache_npm_cache:
-    &cache_npm_cache
+  cache_npm_cache: &cache_npm_cache
     save_cache:
       key: cache-v6-{{ .Branch }}-{{ checksum "package.json" }}
       paths:
         - ./node_modules/
 
-  restore_npm_cache:
-    &restore_npm_cache
+  restore_npm_cache: &restore_npm_cache
     restore_cache:
       <<: *npm_cache_keys
 
-  filters_only_main:
-    &filters_only_main
+  filters_only_main: &filters_only_main
     branches:
       only: main
 
-  filters_ignore_main:
-    &filters_ignore_main
+  filters_ignore_main: &filters_ignore_main
     branches:
       ignore: main
 
-  filters_ignore_tags:
-    &filters_ignore_tags
+  filters_ignore_tags: &filters_ignore_tags
     tags:
       ignore: /.*/
 
-  filters_version_tag:
-    &filters_version_tag
+  filters_version_tag: &filters_version_tag
     tags:
       only:
         - /^v?\d+\.\d+\.\d+(?:-beta\.\d+)?$/
@@ -75,8 +66,8 @@ jobs:
       - run:
           name: Checkout next-ci-shared-helpers
           command: git clone --depth 1
-            git@github.com:Financial-Times/next-ci-shared-helpers.git
-            .circleci/shared-helpers
+            git@github.com:Financial-Times/next-ci-shared-helpers.git --branch
+            unpin-heroku .circleci/shared-helpers
       - *restore_npm_cache
       - node/install-npm:
           version: "^7"
@@ -142,14 +133,14 @@ workflows:
           name: build-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.14" ]
+              node-version: [ "16.20", "18.16" ]
       - test:
           requires:
             - build-v<< matrix.node-version >>
           name: test-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.14" ]
+              node-version: [ "16.20", "18.16" ]
 
   build-test-publish:
     when:
@@ -164,7 +155,7 @@ workflows:
           name: build-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.14" ]
+              node-version: [ "16.20", "18.16" ]
       - test:
           filters:
             <<: *filters_version_tag
@@ -173,13 +164,13 @@ workflows:
           name: test-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.14" ]
+              node-version: [ "16.20", "18.16" ]
       - publish:
           context: npm-publish-token
           filters:
             <<: *filters_version_tag
           requires:
-            - test-v16.14
+            - test-v18.16
 
   nightly:
     when:
@@ -196,7 +187,7 @@ workflows:
           name: build-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.14" ]
+              node-version: [ "16.20", "18.16" ]
       - test:
           requires:
             - build-v<< matrix.node-version >>
@@ -204,7 +195,7 @@ workflows:
           name: test-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.14" ]
+              node-version: [ "16.20", "18.16" ]
 
 notify:
   webhooks:

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ demo-certs:
 	@$(DONE)
 
 demo-js:
-	webpack --config demos/webpack.config.js
+	NODE_OPTIONS="--openssl-legacy-provider" webpack --config demos/NODE_OPTIONS="--openssl-legacy-provider" webpack.config.js
 	@$(DONE)
 
 demo-css:
@@ -20,7 +20,7 @@ demo-build: demo-js demo-css
 	@$(DONE)
 
 demo-watch: demo-certs demo-css # demo-css because node-sass doesn't build one at start of watch
-	webpack --watch --config demos/webpack.config.js &
+	NODE_OPTIONS="--openssl-legacy-provider" webpack --watch --config demos/NODE_OPTIONS="--openssl-legacy-provider" webpack.config.js &
 	sass --watch --load-path=node_modules demos/src/demo.scss:demos/public/demo.css &
 	nodemon --ext js,css,html --watch demos/ --watch server/ demos/start.js
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "@financial-times/n-messaging-client",
       "version": "0.0.0",
-      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "js-cookie": "2.2.0",
@@ -47,8 +46,8 @@
         "webpack-cli": "^3.3.10"
       },
       "engines": {
-        "node": "16.x",
-        "npm": "7.x || 8.x"
+        "node": "16.x || 18.x",
+        "npm": "7.x || 8.x || 9.x"
       },
       "peerDependencies": {
         "@financial-times/o-banner": "^4.4.2",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "description": "Lightweight first party messaging for use with \"The Brain\"",
   "main": "main-server.js",
   "scripts": {
-    "prepare": "npx snyk protect || npx snyk protect -d || true",
-    "preinstall": "[ \"$INIT_CWD\" != \"$PWD\" ] || npm_config_yes=true npx check-engine"
+    "prepare": "npx snyk protect || npx snyk protect -d || true"
   },
   "license": "MIT",
   "x-dash": {
@@ -59,12 +58,11 @@
     }
   },
   "volta": {
-    "node": "16.14.1",
-    "npm": "7.20.2"
+    "node": "18.16.0"
   },
   "engines": {
-    "node": "16.x",
-    "npm": "7.x || 8.x"
+    "node": "16.x || 18.x",
+    "npm": "7.x || 8.x || 9.x"
   },
   "peerDependencies": {
     "@financial-times/o-banner": "^4.4.2",


### PR DESCRIPTION
Automatically ran via Platforms' [migration script](https://github.com/Financial-Times/platform-scripts/blob/464d56876a27742dbdee2713a31266cc268ebfe3/upgrade-node-18/upgrade-node-18.ts)