### PR TITLE
Update myft client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "js-cookie": "2.2.0",
-        "next-myft-client": "^10.2.0",
+        "next-myft-client": "^12.1.0",
         "next-session-client": "^4.0.0"
       },
       "devDependencies": {
@@ -8025,18 +8025,17 @@
       "dev": true
     },
     "node_modules/next-myft-client": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/next-myft-client/-/next-myft-client-10.2.0.tgz",
-      "integrity": "sha512-tmCn7kleYGgSd+0kEhwUketVhm0c0Ci87yFODaGPESK7AT+RmTxdC9QA4oSl8Q9izAJz4dPAgC07fPcz2nr2aw==",
-      "hasInstallScript": true,
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/next-myft-client/-/next-myft-client-12.1.0.tgz",
+      "integrity": "sha512-JDnM23YJa3VrVREmnxxMQM01zaTazP+YQl0zFk+Q5rD3VnRpph7hhi/RSQZk7j7MzVvCFBWmQ4pBOMWNM7BfwA==",
       "dependencies": {
         "black-hole-stream": "0.0.1",
         "fetchres": "^1.7.2",
         "next-session-client": "^4.0.0"
       },
       "engines": {
-        "node": "14.x || 16.x",
-        "npm": "7.x || 8.x"
+        "node": "16.x || 18.x",
+        "npm": "7.x || 8.x || 9.x"
       }
     },
     "node_modules/next-session-client": {
@@ -19926,9 +19925,9 @@
       "dev": true
     },
     "next-myft-client": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/next-myft-client/-/next-myft-client-10.2.0.tgz",
-      "integrity": "sha512-tmCn7kleYGgSd+0kEhwUketVhm0c0Ci87yFODaGPESK7AT+RmTxdC9QA4oSl8Q9izAJz4dPAgC07fPcz2nr2aw==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/next-myft-client/-/next-myft-client-12.1.0.tgz",
+      "integrity": "sha512-JDnM23YJa3VrVREmnxxMQM01zaTazP+YQl0zFk+Q5rD3VnRpph7hhi/RSQZk7j7MzVvCFBWmQ4pBOMWNM7BfwA==",
       "requires": {
         "black-hole-stream": "0.0.1",
         "fetchres": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "js-cookie": "2.2.0",
-    "next-myft-client": "^10.2.0",
+    "next-myft-client": "^12.1.0",
     "next-session-client": "^4.0.0"
   },
   "husky": {


### PR DESCRIPTION
next-myft-client is using an insecure FT_Session token.
FT Core are switching off the insecure sessions. ([Slack Thread](https://financialtimes.slack.com/archives/C042NBBTM/p1702907414857149))
We want to have a clean tree with updated next-myft-client and this app is used by next-stream-page and next-myft-page so I believe this needs to be updated even though it is deprecated. 

The changes in version are just: 
- dropping support for node 14 
- Adds support for node 18
- Fix the insecure session thingy