### PR TITLE
Replace `brand-ft-pink` colour use with `ft-pink`

### DIFF
--- a/client/components/top/cop-digital-acquisition/main.scss
+++ b/client/components/top/cop-digital-acquisition/main.scss
@@ -31,7 +31,7 @@
 			@include oTypographySans($scale: 0);
 
 			.o-message__content-highlight {
-				color: oColorsByName("brand-ft-pink");
+				color: oColorsByName("ft-pink");
 				@include oTypographySans($scale: 2);
 
 				@include oGridRespondTo($from: M) {
@@ -75,7 +75,7 @@
 
 .o-message__actions__primary {
 	padding: oSpacingByName("s2") oSpacingByName("s6");
-	background-color: oColorsByName("brand-ft-pink");
+	background-color: oColorsByName("ft-pink");
 	color: oColorsByName("slate");
 	border-color: transparent;
 

--- a/client/components/top/digital-marketing-new-world/main.scss
+++ b/client/components/top/digital-marketing-new-world/main.scss
@@ -32,7 +32,7 @@
 				@include oTypographySans($scale: 0);
 
 				.o-message__content-highlight {
-					color: oColorsByName('brand-ft-pink');
+					color: oColorsByName('ft-pink');
 					@include oTypographySans($scale: 2);
 
 					@include oGridRespondTo($from: M) {
@@ -76,7 +76,7 @@
 
 	.o-message__actions__primary {
 		padding: oSpacingByName('s2') oSpacingByName('s6');
-		background-color: oColorsByName('brand-ft-pink');
+		background-color: oColorsByName('ft-pink');
 		color: oColorsByName('slate');
 		border-color: transparent;
 

--- a/client/components/top/jan-22-digital-sale-banner/main.scss
+++ b/client/components/top/jan-22-digital-sale-banner/main.scss
@@ -32,7 +32,7 @@
 				@include oTypographySans($scale: 0);
 
 				.o-message__content-highlight {
-					color: oColorsByName('brand-ft-pink');
+					color: oColorsByName('ft-pink');
 					@include oTypographySans($scale: 2);
 
 					@include oGridRespondTo($from: M) {
@@ -81,7 +81,7 @@
 
 	.o-message__actions__primary {
 		padding: oSpacingByName('s2') oSpacingByName('s6');
-		background-color: oColorsByName('brand-ft-pink');
+		background-color: oColorsByName('ft-pink');
 		color: oColorsByName('slate');
 		border-color: transparent;
 


### PR DESCRIPTION
The name `brand-ft-pink` is deprecated and causing annoying Sass warnings for projects which include n-messaging-client.

Replace `brand-ft-pink` with `ft-pink`. 

```
/next-home-page/apps/home-page/client/main.scssWarning: The color "brand-ft-pink" is deprecated for your brand's palette, and will be removed in the next major. Replace "brand-ft-pink" with "ft-pink". This is so we can align our naming with our designers, including the Brand team.
    node_modules/@financial-times/o-colors/src/scss/_functions.scss 30:3                oColorsByName()
    node_modules/@financial-times/n-exponea/styles/digitalMarketingNewWorld.scss 34:13  @import
    node_modules/@financial-times/n-exponea/main.scss 8:9                               @import
    stdin 83:9                                                                          root stylesheet
```