### PR TITLE
Remove snyk [automated]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,8 +110,6 @@ jobs:
       - run:
           name: shared-helper / npm-store-auth-token
           command: .circleci/shared-helpers/helper-npm-store-auth-token
-      - run: npx snyk monitor --org=customer-products
-          --project-name=Financial-Times/n-messaging-client
       - run:
           name: shared-helper / npm-version-and-publish-public
           command: .circleci/shared-helpers/helper-npm-version-and-publish-public

--- a/.snyk
+++ b/.snyk
@@ -1,4 +1,0 @@
-# Snyk (https://snyk.io) policy file, which patches or ignores known vulnerabilities.
-version: v1.13.5
-ignore: {}
-patch: {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,6 @@
         "request": "^2.87.0",
         "sass": "^1.49.9",
         "sinon": "^6.0.0",
-        "snyk": "^1.168.0",
         "sucrase": "^3.12.1",
         "webpack": "^4.41.5",
         "webpack-cli": "^3.3.10"
@@ -10705,18 +10704,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/snyk": {
-      "version": "1.931.0",
-      "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.931.0.tgz",
-      "integrity": "sha512-anaEdv5e7BugJeRWuT5tviW46ABmOoPb8+4Ijv+kjZvKa6zCIKL0i8kODKmOpOENGAs+2qrAJPI3dAEUPQiAdg==",
-      "dev": true,
-      "bin": {
-        "snyk": "bin/snyk"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/source-list-map": {
@@ -22047,12 +22034,6 @@
       "requires": {
         "kind-of": "^3.2.0"
       }
-    },
-    "snyk": {
-      "version": "1.931.0",
-      "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.931.0.tgz",
-      "integrity": "sha512-anaEdv5e7BugJeRWuT5tviW46ABmOoPb8+4Ijv+kjZvKa6zCIKL0i8kODKmOpOENGAs+2qrAJPI3dAEUPQiAdg==",
-      "dev": true
     },
     "source-list-map": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -4,9 +4,7 @@
   "repository": "Financial-Times/n-messaging-client",
   "description": "Lightweight first party messaging for use with \"The Brain\"",
   "main": "main-server.js",
-  "scripts": {
-    "prepare": "npx snyk protect || npx snyk protect -d || true"
-  },
+  "scripts": {},
   "license": "MIT",
   "x-dash": {
     "engine": {
@@ -40,7 +38,6 @@
     "request": "^2.87.0",
     "sass": "^1.49.9",
     "sinon": "^6.0.0",
-    "snyk": "^1.168.0",
     "sucrase": "^3.12.1",
     "webpack": "^4.41.5",
     "webpack-cli": "^3.3.10"


### PR DESCRIPTION
In mid-December 2024 we will be letting our Snyk contract expire. We'll
be moving to GitHub Advanced Security as an alternative.

This PR is an attempt to get ahead of the deadline. Considering how out
of date some of our Snyk implementations are, and that we rarely take
the time to merge the PRs, we think it's fine to remove it way ahead of
time.

If you want an interrim solution, enable Dependabot Security updates for
this repository by visiting the following page and clicking 'Enable' next
to 'Dependabot security updates':
https://github.com/Financial-Times/n-messaging-client/settings/security_analysis

You're also free to ignore this PR and do the work yourself closer to
the deadline. Cyber will be doing some broader comms later in the year.

This PR was automated, please take a little extra care when reviewing. I
won't be attempting to fix build failures or small repo-specific quirks
but feel free to build on top of this PR.